### PR TITLE
Prevent loop on reorderMethods()

### DIFF
--- a/view/frontend/web/js/view/payment/method-renderer/alma_monthly_payments.js
+++ b/view/frontend/web/js/view/payment/method-renderer/alma_monthly_payments.js
@@ -45,7 +45,7 @@ define(
 
             function reorderMethods() {
                 var list = region.peek(),
-                    expectedPosition = window.checkoutConfig.payment['alma_monthly_payments'].sortOrder - 1;
+                    expectedPosition = Math.min(list.length, window.checkoutConfig.payment['alma_monthly_payments'].sortOrder) - 1;
 
                 var almaIndex = _.findIndex(list, function(methodComponent) {
                     return methodComponent.item.method === 'alma_monthly_payments';


### PR DESCRIPTION
Problème remonté par un dev :
> Le soucis vient du javascript sur la page de checkout, qui a l'air de déclenché de manière aléatoire (en fonction de la vitesse de chargement de la page ?), l'erreur suivante : 
```knockout.js:20 Uncaught RangeError: Maximum call stack size exceeded
  at ko.computed.disposeWhenNodeIsRemoved (knockout.js:20)
  at Function.evaluateImmediate_CallReadThenEndDependencyDetection (knockout.js:9)
  at Function.evaluateImmediate_CallReadWithDependencyDetection (knockout.js:9)
  at Function.evaluateImmediate (knockout.js:9)
  at Function.evaluatePossiblyAsync (knockout.js:9)
  at Function.notifySubscribers (knockout.js:6)
  at Function.valueHasMutated (knockout.js:7)
  at ko.subscription.reorderMethods [as callback] (alma_monthly_payments.js:1)
  at Function.notifySubscribers (knockout.js:6)
  at Function.valueHasMutated (knockout.js:7)
  at ko.subscription.reorderMethods [as callback] (alma_monthly_payments.js:1)
  at Function.notifySubscribers (knockout.js:6)
  at Function.valueHasMutated (knockout.js:7)
  at ko.subscription.reorderMethods [as callback] (alma_monthly_payments.js:1)
  at Function.notifySubscribers (knockout.js:6)
  at Function.valueHasMutated (knockout.js:7)
```
> Lorsque l'erreur est déclenchée, le paiement Alma n'apparait pas dans la liste des choix. (l'erreurr vient d'une section de code qui cherche à réordonner les modes de paiement dans la liste de choix).
J'ai changé la configuration du mode de paiement Alma pour le passer en position 2 (je l'avais mis à 10 à l'origine). Le problème n'a pas l'air de se reproduire.

Voir [discussion sur #dev-support](https://almapay.slack.com/archives/CP1SUFY3U/p1587637153018800?thread_ts=1587629479.011300&cid=CP1SUFY3U).