### PR TITLE
Use own class instead of a paypal class

### DIFF
--- a/Block/Adminhtml/System/Config/Fieldset/Payment.php
+++ b/Block/Adminhtml/System/Config/Fieldset/Payment.php
@@ -1,0 +1,136 @@
+<?php
+
+/**
+ * 2018-2021 Alma / Nabla SAS
+ *
+ * THE MIT LICENSE
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated
+ * documentation files (the "Software"), to deal in the Software without restriction, including without limitation
+ * the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and
+ * to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+ * The above copyright notice and this permission notice shall be included in all copies or substantial portions of the
+ * Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE
+ * WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF
+ * CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
+ * IN THE SOFTWARE.
+ *
+ * @author    Alma / Nabla SAS <contact@getalma.eu>
+ * @copyright 2018-2021 Alma / Nabla SAS
+ * @license   https://opensource.org/licenses/MIT The MIT License
+ */
+
+namespace Alma\MonthlyPayments\Block\Adminhtml\System\Config\Fieldset;
+
+use Magento\Config\Block\System\Config\Form\Fieldset;
+use Magento\Framework\Data\Form\Element\AbstractElement;
+
+class Payment extends Fieldset
+{
+    /**
+     * Add custom css class
+     *
+     * @param AbstractElement $element
+     *
+     * @return string
+     */
+    protected function _getFrontendClass($element)
+    {
+        return parent::_getFrontendClass($element) . ' with-button';
+    }
+
+    /**
+     * Return header title part of html for payment solution
+     *
+     * @param AbstractElement $element
+     * @return string
+     */
+    protected function _getHeaderTitleHtml($element)
+    {
+        $html = '<div class="config-heading" >';
+        $htmlId = $element->getHtmlId();
+        $html .= '<div class="button-container"><button type="button"' .
+                 ' class="button action-configure' .
+                 '" id="' .
+                 $htmlId .
+                 '-head" onclick="almaToggleSolution.call(this, \'' .
+                 $htmlId .
+                 "', '" .
+                 $this->getUrl(
+                     'adminhtml/*/state'
+                 ) . '\'); return false;"><span class="state-closed">' . __(
+                     'Configure'
+                 ) . '</span><span class="state-opened">' . __(
+                     'Close'
+                 ) . '</span></button>';
+
+        $html .= '</div>';
+        $html .= '<div class="heading"><strong>' . $element->getLegend() . '</strong>';
+
+        if ($element->getComment()) {
+            $html .= '<span class="heading-intro">' . $element->getComment() . '</span>';
+        }
+        $html .= '<div class="config-alt"></div>';
+        $html .= '</div></div>';
+
+        return $html;
+    }
+
+    /**
+     * Return header comment part of html for payment solution
+     *
+     * @param AbstractElement $element
+     * @return string
+     * @SuppressWarnings(PHPMD.UnusedFormalParameter)
+     */
+    protected function _getHeaderCommentHtml($element)
+    {
+        return '';
+    }
+
+    /**
+     * Get collapsed state on-load
+     *
+     * @param AbstractElement $element
+     * @return false
+     * @SuppressWarnings(PHPMD.UnusedFormalParameter)
+     */
+    protected function _isCollapseState($element)
+    {
+        return false;
+    }
+
+    /**
+     * Return extra Js.
+     *
+     * @param AbstractElement $element
+     * @return string
+     * @SuppressWarnings(PHPMD.UnusedFormalParameter)
+     */
+    protected function _getExtraJs($element)
+    {
+        $script = "require(['jquery', 'prototype'], function(jQuery){
+            window.almaToggleSolution = function (id, url) {
+                var doScroll = false;
+                Fieldset.toggleCollapse(id, url);
+                if ($(this).hasClassName(\"open\")) {
+                    \$$(\".with-button button.button\").each(function(anotherButton) {
+                        if (anotherButton != this && $(anotherButton).hasClassName(\"open\")) {
+                            $(anotherButton).click();
+                            doScroll = true;
+                        }
+                    }.bind(this));
+                }
+                if (doScroll) {
+                    var pos = Element.cumulativeOffset($(this));
+                    window.scrollTo(pos[0], pos[1] - 45);
+                }
+            }
+        });";
+
+        return $this->_jsHelper->getScript($script);
+    }
+}

--- a/etc/adminhtml/system.xml
+++ b/etc/adminhtml/system.xml
@@ -33,7 +33,7 @@
                    showInWebsite="1" showInStore="1">
                 <comment><![CDATA[<div class="alma-payment-logo"></div><div class="alma-payment-text">Offer installments payments with Alma and instantly boost your sales.<br>Increase average order value by 60% and your sales by 20%.<br>With no subscription fees and no commitment, it’s risk free: you are paid upfront while your customers pay later.</div>]]></comment>
                 <fieldset_css>complex alma-section</fieldset_css>
-                <frontend_model>Magento\Paypal\Block\Adminhtml\System\Config\Fieldset\Payment</frontend_model>
+                <frontend_model>Alma\MonthlyPayments\Block\Adminhtml\System\Config\Fieldset\Payment</frontend_model>
 
                 <field id="active" translate="label" type="select" sortOrder="1" showInDefault="1" showInWebsite="1"
                        showInStore="1">


### PR DESCRIPTION
Since version 1.2.0, the alma module uses a PayPal class for the payment configuration dropdown.

It is not recommended using the class of another payment method, because if the module is not installed in the project, the back office is broken. (ex: use "replace" in composer to remove PayPal module)

I'm based on klarna class because it contains the minimum necessary without adding extra functionality that is not used