### PR TITLE
Compatible with Monolog\Logger

### DIFF
--- a/Helpers/Logger.php
+++ b/Helpers/Logger.php
@@ -71,12 +71,12 @@ class Logger extends Monolog
      * @param array $context
      * @return bool
      */
-    public function addRecord($level, $message, array $context = []): bool
+    public function addRecord($level, $message, array $context = [], ?\Monolog\DateTimeImmutable $datetime = null): bool
     {
         if (!$this->configHelper->canLog()) {
             return true;
         }
 
-        return parent::addRecord($level, $message, $context);
+        return parent::addRecord($level, $message, $context, $datetime);
     }
 }


### PR DESCRIPTION
Missing a param for the parent calling.

Throw a fatal error : 

> PHP Fatal error:  Declaration of `Alma\MonthlyPayments\Helpers\Logger::addRecord($level, $message, array $context = [])`: bool must be compatible with `Monolog\Logger::addRecord(int $level, string $message, array $context = [], ?Monolog\DateTimeImmutable $datetime = null)`: bool in /vendor/alma/alma-monthlypayments-magento2/Helpers/Logger.php on line 74