### PR TITLE
fix:getProduct from registry updated

### DIFF
--- a/Block/Catalog/Product/View.php
+++ b/Block/Catalog/Product/View.php
@@ -71,6 +71,11 @@ class View extends Template
      * @var WidgetConfigHelper
      */
     private $widgetConfigHelper;
+    
+    /**
+     * @var Context
+     */
+    private $context;
 
     /**
      * @param Context $context
@@ -96,6 +101,7 @@ class View extends Template
         $this->config = $config;
         $this->registry = $registry;
         $this->localeResolver = $localeResolver;
+        $this->context = $context;
         $this->getProduct();
         $this->getPlans();
         $this->apiConfigHelper = $apiConfigHelper;
@@ -108,7 +114,7 @@ class View extends Template
      */
     private function getProduct()
     {
-        $this->product = $this->registry->registry('product');
+        $this->product = $this->context->getRegistry()->registry('product');
         if (!$this->product->getId()) {
             throw new LocalizedException(__('Failed to initialize product'));
         }


### PR DESCRIPTION
Fixes  #63  CRITICAL

[2022-09-22T11:47:35.244653+00:00] main.CRITICAL: Error: Call to a member function getId() on null in /var/www/xxxxx/vendor/alma/alma-monthlypayments-magento2/Block/Catalog/Product/View.php:96
Stack trace:
#0 /var/www/xxx/vendor/alma/alma-monthlypayments-magento2/Block/Catalog/Product/View.php(85): Alma\MonthlyPayments\Block\Catalog\Product\View->getProduct()
