### PR TITLE
fix: add cdn.jsdelivr.net as a valid font-src

### DIFF
--- a/etc/csp_whitelist.xml
+++ b/etc/csp_whitelist.xml
@@ -15,6 +15,7 @@
         </policy>
         <policy id="font-src">
             <values>
+                <value id="jsdelivr_cdn" type="host">cdn.jsdelivr.net</value>
                 <value id="fonts_gstatic" type="host">fonts.gstatic.com</value>
             </values>
         </policy>


### PR DESCRIPTION
```
Content Security Policy: The page’s settings observed the loading of a resource at https://cdn.jsdelivr.net/npm/@alma/widgets@3.x.x/dist/assets/fonts/Venn-Regular.eot?#iefix (“font-src”). A CSP report is being sent.
Content Security Policy: The page’s settings observed the loading of a resource at https://cdn.jsdelivr.net/npm/@alma/widgets@3.x.x/dist/assets/fonts/Venn-Regular.woff (“font-src”). A CSP report is being sent.
Content Security Policy: The page’s settings observed the loading of a resource at https://cdn.jsdelivr.net/npm/@alma/widgets@3.x.x/dist/assets/fonts/Venn-Regular.ttf (“font-src”). A CSP report is being sent.
Content Security Policy: The page’s settings observed the loading of a resource at https://cdn.jsdelivr.net/npm/@alma/widgets@3.x.x/dist/assets/fonts/Venn-Bold.eot (“font-src”). A CSP report is being sent.
Content Security Policy: The page’s settings observed the loading of a resource at https://cdn.jsdelivr.net/npm/@alma/widgets@3.x.x/dist/assets/fonts/Venn-Bold.woff (“font-src”). A CSP report is being sent.
Content Security Policy: The page’s settings observed the loading of a resource at https://cdn.jsdelivr.net/npm/@alma/widgets@3.x.x/dist/assets/fonts/Venn-Bold.ttf (“font-src”). A CSP report is being sent.
Content Security Policy: The page’s settings observed the loading of a resource at https://cdn.jsdelivr.net/npm/@alma/widgets@3.x.x/dist/assets/fonts/ArgentCF-DemiBold.eot (“font-src”). A CSP report is being sent.
Content Security Policy: The page’s settings observed the loading of a resource at https://cdn.jsdelivr.net/npm/@alma/widgets@3.x.x/dist/assets/fonts/ArgentCF-DemiBold.woff (“font-src”). A CSP report is being sent.
Content Security Policy: The page’s settings observed the loading of a resource at https://cdn.jsdelivr.net/npm/@alma/widgets@3.x.x/dist/assets/fonts/ArgentCF-DemiBold.ttf (“font-src”). A CSP report is being sent.
Content Security Policy: The page’s settings observed the loading of a resource at https://cdn.jsdelivr.net/npm/@alma/widgets@3.x.x/dist/assets/fonts/Venn-Bold.woff (“font-src”). A CSP report is being sent.
Content Security Policy: The page’s settings observed the loading of a resource at https://cdn.jsdelivr.net/npm/@alma/widgets@3.x.x/dist/assets/fonts/Venn-Regular.woff (“font-src”). A CSP report is being sent.
```