### PR TITLE
Feature : MPP 69 retrieve 10 past purchase

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 Changelog
 =========
+v3.4.0
+------
+
+* feat: Add data for Alma Risk - 10 past purchases
+* fix: Fix return SEPA issue
 
 v3.3.0
 ------

--- a/Gateway/Http/TransferFactory.php
+++ b/Gateway/Http/TransferFactory.php
@@ -25,7 +25,7 @@
 
 namespace Alma\MonthlyPayments\Gateway\Http;
 
-use Alma\MonthlyPayments\Gateway\Config\Config;
+
 use Magento\Payment\Gateway\Http\TransferBuilder;
 use Magento\Payment\Gateway\Http\TransferFactoryInterface;
 use Magento\Payment\Gateway\Http\TransferInterface;
@@ -36,21 +36,14 @@ class TransferFactory implements TransferFactoryInterface
      * @var TransferBuilder
      */
     private $transferBuilder;
-    /**
-     * @var Config
-     */
-    private $config;
 
     /**
      * @param TransferBuilder $transferBuilder
-     * @param Config $config
      */
     public function __construct(
-        TransferBuilder $transferBuilder,
-        Config $config
+        TransferBuilder $transferBuilder
     ) {
         $this->transferBuilder = $transferBuilder;
-        $this->config = $config;
     }
 
     /**

--- a/Gateway/Request/CartDataBuilder.php
+++ b/Gateway/Request/CartDataBuilder.php
@@ -24,51 +24,29 @@
 
 namespace Alma\MonthlyPayments\Gateway\Request;
 
-use Alma\MonthlyPayments\Helpers\Functions;
 use Alma\MonthlyPayments\Helpers\Logger;
-use Alma\MonthlyPayments\Helpers\ProductHelper;
-use Magento\Catalog\Model\Category;
-use Magento\Catalog\Model\Product;
-use Magento\Catalog\Model\ResourceModel\Category\Collection;
-use Magento\Catalog\Model\ResourceModel\Product\Collection as ProductCollection;
-use Magento\Framework\Exception\NoSuchEntityException;
-use Magento\Framework\UrlInterface;
+use Alma\MonthlyPayments\Helpers\OrderHelper;
 use Magento\Payment\Gateway\Helper\SubjectReader;
 use Magento\Payment\Gateway\Request\BuilderInterface;
-use Magento\Sales\Model\Order\Item;
-use Magento\Store\Model\StoreManagerInterface;
 
 /**
  * CartDataBuilder build Cart Data for Alma credit Payment Payload
  */
 class CartDataBuilder implements BuilderInterface
 {
-    /**
-     * @var Logger
-     */
     private $logger;
-    /**
-     * @var StoreManagerInterface
-     */
-    private $storeManager;
-    /**
-     * @var ProductHelper
-     */
-    private $productHelper;
+    private $orderHelper;
 
     /**
      * @param Logger $logger
-     * @param StoreManagerInterface $storeManager
-     * @param ProductHelper $productHelper
+     * @param OrderHelper $orderHelper
      */
     public function __construct(
         Logger $logger,
-        StoreManagerInterface $storeManager,
-        ProductHelper $productHelper
+        OrderHelper $orderHelper
     ) {
         $this->logger = $logger;
-        $this->storeManager = $storeManager;
-        $this->productHelper = $productHelper;
+        $this->orderHelper = $orderHelper;
     }
 
     /**
@@ -81,141 +59,12 @@ class CartDataBuilder implements BuilderInterface
     {
         $paymentDO = SubjectReader::readPayment($buildSubject);
         $orderItems = $paymentDO->getOrder()->getItems();
-        $productsIds = $this->getProductsIds($orderItems);
-        $products = $this->productHelper->getProductsItems($productsIds);
-        $productsCategories = $this->productHelper->getProductsCategories($products);
-        $categories = $this->formatCategoriesInArray($productsCategories);
-        $dataForCartItemPayload = $this->formatDataForPayload($orderItems, $products, $categories);
-
+        $items = $this->orderHelper->formatOrderItems($orderItems);
+        $this->logger->info('Credit Items in cart', [$items]);
         return [
             'cart' => [
-                'items' =>  $this->formatOrderItems($dataForCartItemPayload)
+                'items' =>  $items
             ],
         ];
-    }
-
-    /**
-     * Parse order items for formatting
-     *
-     * @param array $dataProducts
-     * @return array
-     */
-    private function formatOrderItems(array $dataProducts): array
-    {
-        $formattedItems = [];
-
-        foreach ($dataProducts as $data) {
-            if (isset($data['item']) && isset($data['product']) && isset($data['categories'])) {
-                $formattedItems[] = $this->formatItem($data);
-            } else {
-                $this->logger->warning(' Error with cart data payload', [$data]);
-            }
-        }
-        return $formattedItems;
-    }
-
-    /**
-     * Format array with order item, product, and categories for payment payload
-     *
-     * @param array $data
-     * @return array
-     */
-    private function formatItem(array $data): array
-    {
-        return [
-            'sku' => $data['item']->getSku(),
-            'vendor' => '',
-            'title' => $data['item']->getName(),
-            'variant_title' => $data['item']->getProductOptions()['simple_name'] ?? '',
-            'quantity' => (int) $data['item']->getQtyOrdered(),
-            'unit_price' => Functions::priceToCents($data['item']->getPriceInclTax()),
-            'line_price' => Functions::priceToCents($data['item']->getBaseRowTotalInclTax()),
-            'is_gift' => false,
-            'categories' => $data['categories'],
-            'url' => $data['product']->getProductUrl(),
-            'picture_url' => $this->getMediaUrl($data['product']->getImage()),
-            'requires_shipping' => !$data['item']->getIsVirtual(),
-            'taxes_included' => (bool) $data['item']->getTaxAmount()
-        ];
-    }
-
-    /**
-     * Return media url for a product
-     *
-     * @param string $path
-     * @return string
-     */
-    private function getMediaUrl(string $path): string
-    {
-        try {
-            return $this->storeManager->getStore()->getBaseUrl(UrlInterface::URL_TYPE_MEDIA) . 'catalog/product' . $path;
-        } catch (NoSuchEntityException $e) {
-            $this->logger->warning('Error in get media base url:', [$e->getMessage()]);
-        }
-
-        return '';
-    }
-
-    /**
-     * Get all non dummy productsIds for orderItems
-     *
-     * @param array $orderItems
-     * @return array
-     */
-    private function getProductsIds(array $orderItems): array
-    {
-        $productsIds = [];
-        foreach ($orderItems as $item) {
-            if (!$item->isDummy()) {
-                $productsIds[] = $item->getProductId();
-            }
-        }
-        return $productsIds;
-    }
-
-    /**
-     * Format categories collection in associative array ['entity_id' => Category]
-     *
-     * @param Collection $productsCategories
-     * @return array
-     */
-    private function formatCategoriesInArray(Collection $productsCategories): array
-    {
-        $categories = [];
-        foreach ($productsCategories as $category) {
-            /** @var Category $category */
-            $categories[$category->getEntityId()] = $category->getName();
-        }
-        return $categories;
-    }
-
-    /**
-     * @param array $orderItems
-     * @param ProductCollection $products
-     * @param array $categories
-     * @return array
-     */
-    private function formatDataForPayload(array $orderItems, ProductCollection $products, array $categories): array
-    {
-        $dataForCartItemPayload = [];
-        foreach ($orderItems as $item) {
-            /** @var Item $item */
-            if (!$item->isDummy()) {
-                $dataForCartItemPayload[$item->getProductId()]['item'] = $item;
-            }
-        }
-
-        foreach ($products as $product) {
-            /** @var Product $product */
-            $dataForCartItemPayload[$product->getEntityId()]['product'] = $product;
-            $productCategoriesNames = [];
-            foreach ($product->getCategoryIds() as $categoryId) {
-                if (isset($categories[$categoryId])) {
-                    $productCategoriesNames[] = $categories[$categoryId];
-                }
-            }
-            $dataForCartItemPayload[$product->getEntityId()]['categories'] = $productCategoriesNames;
-        }
-        return $dataForCartItemPayload;
     }
 }

--- a/Gateway/Request/CartDataBuilder.php
+++ b/Gateway/Request/CartDataBuilder.php
@@ -60,7 +60,6 @@ class CartDataBuilder implements BuilderInterface
         $paymentDO = SubjectReader::readPayment($buildSubject);
         $orderItems = $paymentDO->getOrder()->getItems();
         $items = $this->orderHelper->formatOrderItems($orderItems);
-        $this->logger->info('Credit Items in cart', [$items]);
         return [
             'cart' => [
                 'items' =>  $items

--- a/Gateway/Request/OrderDataBuilder.php
+++ b/Gateway/Request/OrderDataBuilder.php
@@ -52,6 +52,7 @@ class OrderDataBuilder implements BuilderInterface
      */
     public function build(array $buildSubject)
     {
+
         $paymentDO = SubjectReader::readPayment($buildSubject);
         /** @var OrderAdapter $order */
         $order = $paymentDO->getOrder();

--- a/Gateway/Request/OrderDataBuilder.php
+++ b/Gateway/Request/OrderDataBuilder.php
@@ -22,12 +22,8 @@
  * @license   https://opensource.org/licenses/MIT The MIT License
  */
 
-
 namespace Alma\MonthlyPayments\Gateway\Request;
 
-use Alma\MonthlyPayments\Model\Data\Quote as AlmaQuote;
-use Magento\Checkout\Model\Session as CheckoutSession;
-use Magento\Framework\UrlInterface;
 use Magento\Payment\Gateway\Helper\SubjectReader;
 use Magento\Payment\Gateway\Request\BuilderInterface;
 

--- a/Gateway/Request/WebsiteCustomerDetailsDataBuilder.php
+++ b/Gateway/Request/WebsiteCustomerDetailsDataBuilder.php
@@ -53,12 +53,10 @@ class WebsiteCustomerDetailsDataBuilder implements BuilderInterface
     }
 
     /**
-     * Builds ENV request
+     * Build website_customer_details data
      *
      * @param array $buildSubject
      * @return array
-     * @throws \Magento\Framework\Exception\LocalizedException
-     * @throws \Magento\Framework\Exception\NoSuchEntityException
      */
     public function build(array $buildSubject)
     {
@@ -78,14 +76,6 @@ class WebsiteCustomerDetailsDataBuilder implements BuilderInterface
                 $previousOrders[] = $this->formatPreviousOrderForPaymentPayload($previousOrder);
             }
         }
-        $this->logger->info('Previous Order', [
-            [
-                'website_customer_details' => [
-                    'is_guest' => $isGuest,
-                    'previous_orders' => $previousOrders
-                ]
-            ]
-        ]);
         return [
             'website_customer_details' => [
                 'is_guest' => $isGuest,
@@ -95,10 +85,12 @@ class WebsiteCustomerDetailsDataBuilder implements BuilderInterface
     }
 
     /**
-    * @param OrderInterface | OrderAdapterInterface $order
-    * @return array
+     * Format Previous orders data
+     *
+     * @param OrderInterface $order
+     * @return array
      */
-    private function formatPreviousOrderForPaymentPayload($order): array
+    private function formatPreviousOrderForPaymentPayload(OrderInterface $order): array
     {
         return [
             "purchase_amount"=> Functions::priceToCents($order->getGrandTotal()),

--- a/Gateway/Request/WebsiteCustomerDetailsDataBuilder.php
+++ b/Gateway/Request/WebsiteCustomerDetailsDataBuilder.php
@@ -28,7 +28,6 @@ use Alma\MonthlyPayments\Helpers\Functions;
 use Alma\MonthlyPayments\Helpers\Logger;
 use Alma\MonthlyPayments\Helpers\OrderHelper;
 use Magento\Payment\Gateway\Data\Order\OrderAdapter;
-use Magento\Payment\Gateway\Data\OrderAdapterInterface;
 use Magento\Payment\Gateway\Helper\SubjectReader;
 use Magento\Payment\Gateway\Request\BuilderInterface;
 use Magento\Sales\Api\Data\OrderInterface;

--- a/Gateway/Request/WebsiteCustomerDetailsDataBuilder.php
+++ b/Gateway/Request/WebsiteCustomerDetailsDataBuilder.php
@@ -25,21 +25,28 @@
 namespace Alma\MonthlyPayments\Gateway\Request;
 
 use Alma\MonthlyPayments\Helpers\Logger;
+use Alma\MonthlyPayments\Helpers\OrderHelper;
 use Magento\Payment\Gateway\Data\Order\OrderAdapter;
 use Magento\Payment\Gateway\Helper\SubjectReader;
 use Magento\Payment\Gateway\Request\BuilderInterface;
 
-class OrderDataBuilder implements BuilderInterface
+class WebsiteCustomerDetailsDataBuilder implements BuilderInterface
 {
     /**
      * @var Logger
      */
     private $logger;
+    /**
+     * @var OrderHelper
+     */
+    private $orderHelper;
 
     public function __construct(
-        Logger $logger
+        Logger $logger,
+        OrderHelper $orderHelper
     ) {
         $this->logger = $logger;
+        $this->orderHelper = $orderHelper;
     }
 
     /**
@@ -52,13 +59,26 @@ class OrderDataBuilder implements BuilderInterface
      */
     public function build(array $buildSubject)
     {
+        $this->logger->info('coucou');
         $paymentDO = SubjectReader::readPayment($buildSubject);
+        $this->logger->info('coucou2');
+
         /** @var OrderAdapter $order */
         $order = $paymentDO->getOrder();
+        $this->logger->info('coucou3');
+
+        $previousOrders = [];
+        if ($order->getCustomerId()) {
+            $this->logger->info('coucou5');
+            $previousOrders2 = $this->orderHelper->getOrderCollectionByCustomerId($order->getCustomerId());
+            $this->logger->info('coucou6');
+            $this->logger->info("Previous order collection", [$previousOrders2]);
+        }
+        $this->logger->info('coucou4');
 
         return [
-            'order' => [
-                'merchant_reference' => $order->getOrderIncrementId()
+            'website_customer_details' => [
+                'previous_orders' => $previousOrders
             ]
         ];
     }

--- a/Gateway/Response/ResponseHandler.php
+++ b/Gateway/Response/ResponseHandler.php
@@ -59,8 +59,6 @@ class ResponseHandler implements HandlerInterface
 
         /** @var Payment $almaPayment */
         $almaPayment = $response['almaPayment'];
-        $this->logger->info('AlmaPayment', [$almaPayment]);
-        $this->logger->info('AlmaPayment url', [$almaPayment->url]);
         $payment->setTransactionId($almaPayment->id);
         $payment->setAdditionalInformation(Config::ORDER_PAYMENT_ID, $almaPayment->id);
         $payment->setAdditionalInformation(Config::ORDER_PAYMENT_URL, $almaPayment->url);

--- a/Gateway/Response/ResponseHandler.php
+++ b/Gateway/Response/ResponseHandler.php
@@ -27,12 +27,22 @@ namespace Alma\MonthlyPayments\Gateway\Response;
 
 use Alma\API\Entities\Payment;
 use Alma\MonthlyPayments\Gateway\Config\Config;
+use Alma\MonthlyPayments\Helpers\Logger;
 use Magento\Payment\Gateway\Helper\SubjectReader;
 use Magento\Payment\Gateway\Response\HandlerInterface;
 use Magento\Sales\Model\Order;
 
 class ResponseHandler implements HandlerInterface
 {
+    /**
+     * @var Logger
+     */
+    private $logger;
+
+    public function __construct(Logger $logger)
+    {
+        $this->logger = $logger;
+    }
     /**
      * Handles transaction id
      *
@@ -49,7 +59,8 @@ class ResponseHandler implements HandlerInterface
 
         /** @var Payment $almaPayment */
         $almaPayment = $response['almaPayment'];
-
+        $this->logger->info('AlmaPayment', [$almaPayment]);
+        $this->logger->info('AlmaPayment url', [$almaPayment->url]);
         $payment->setTransactionId($almaPayment->id);
         $payment->setAdditionalInformation(Config::ORDER_PAYMENT_ID, $almaPayment->id);
         $payment->setAdditionalInformation(Config::ORDER_PAYMENT_URL, $almaPayment->url);

--- a/Helpers/OrderHelper.php
+++ b/Helpers/OrderHelper.php
@@ -3,11 +3,9 @@
 namespace Alma\MonthlyPayments\Helpers;
 
 use Magento\Catalog\Model\Category;
-use Magento\Catalog\Model\Product;
 use Magento\Catalog\Model\ResourceModel\Product\Collection as ProductCollection;
 use Magento\Framework\App\Helper\AbstractHelper;
 use Magento\Framework\App\Helper\Context;
-use Magento\Framework\Exception\LocalizedException;
 use Magento\Framework\Exception\NoSuchEntityException;
 use Magento\Framework\UrlInterface;
 use Magento\Sales\Api\Data\OrderInterface;
@@ -23,9 +21,7 @@ use Magento\Store\Model\StoreManagerInterface;
 class OrderHelper extends AbstractHelper
 {
     /**
-     * @param OrderInterface $order
-     *
-     * @return string
+     * @var OrderFactory
      */
     private $orderFactory;
     /**
@@ -36,11 +32,33 @@ class OrderHelper extends AbstractHelper
      * @var OrderRepositoryInterface
      */
     private $orderRepository;
-    private $orderCollectionFactory;
+    /**
+     * @var Logger
+     */
     private $logger;
+    /**
+     * @var ProductHelper
+     */
     private $productHelper;
+    /**
+     * @var CollectionFactory
+     */
+    private $orderCollectionFactory;
+    /**
+     * @var StoreManagerInterface
+     */
     private $storeManager;
 
+    /**
+     * @param Context $context
+     * @param OrderFactory $orderFactory
+     * @param CollectionFactory $orderCollectionFactory
+     * @param OrderRepositoryInterface $orderRepository
+     * @param OrderManagementInterface $orderManagement
+     * @param ProductHelper $productHelper
+     * @param StoreManagerInterface $storeManager
+     * @param Logger $logger
+     */
     public function __construct(
         Context $context,
         OrderFactory $orderFactory,
@@ -97,6 +115,7 @@ class OrderHelper extends AbstractHelper
 
     /**
      * Performs persist operations for a specified order.
+     *
      * @param Order $order
      *
      * @return void
@@ -108,10 +127,11 @@ class OrderHelper extends AbstractHelper
 
     /**
      * Get an order collection
+     *
      * @param int $customerId
      * @return Collection
      */
-    public function getValidOrderCollectionByCustomerId(int $customerId): Collection
+    public function getValidOrderCollectionByCustomerId(int  $customerId): Collection
     {
         return $this->orderCollectionFactory->create($customerId)
         ->addFieldToSelect('*')
@@ -135,6 +155,7 @@ class OrderHelper extends AbstractHelper
     }
     /**
      * Get payment methode by order;
+     *
      * @param Order $order
      * @return string
      */
@@ -145,7 +166,7 @@ class OrderHelper extends AbstractHelper
     /**
      * Parse order items for formatting
      *
-     * @param array $dataProducts
+     * @param array $orderItems
      * @return array
      */
     public function formatOrderItems(array $orderItems): array
@@ -162,9 +183,10 @@ class OrderHelper extends AbstractHelper
     }
 
     /**
+     * Format order items for payment payload
+     *
      * @param array $orderItems
      * @return mixed
-     * @throws LocalizedException
      */
     private function formatOrderItemsForPaymentPayload(array $orderItems)
     {
@@ -172,6 +194,7 @@ class OrderHelper extends AbstractHelper
         $products = $this->productHelper->getProductsItems($productsIds);
         $productsCategories = $this->productHelper->getProductsCategories($products);
         $categories = $this->formatCategoriesInArray($productsCategories);
+
         return $this->formatDataForPayload($orderItems, $products, $categories);
     }
     /**
@@ -188,6 +211,7 @@ class OrderHelper extends AbstractHelper
                 $productsIds[] = $item->getProductId();
             }
         }
+
         return $productsIds;
     }
     /**
@@ -207,6 +231,8 @@ class OrderHelper extends AbstractHelper
     }
 
     /**
+     * Format orderItems, products and categories for payment payload
+     *
      * @param array $orderItems
      * @param ProductCollection $products
      * @param array $categories
@@ -223,7 +249,6 @@ class OrderHelper extends AbstractHelper
         }
 
         foreach ($products as $product) {
-            /** @var Product $product */
             $dataForCartItemPayload[$product->getEntityId()]['product'] = $product;
             $productCategoriesNames = [];
             foreach ($product->getCategoryIds() as $categoryId) {
@@ -233,6 +258,7 @@ class OrderHelper extends AbstractHelper
             }
             $dataForCartItemPayload[$product->getEntityId()]['categories'] = $productCategoriesNames;
         }
+
         return $dataForCartItemPayload;
     }
     /**

--- a/Helpers/OrderHelper.php
+++ b/Helpers/OrderHelper.php
@@ -31,12 +31,14 @@ class OrderHelper extends AbstractHelper
         Context $context,
         OrderFactory $orderFactory,
         OrderRepositoryInterface $orderRepository,
-        OrderManagementInterface $orderManagement
+        OrderManagementInterface $orderManagement,
+        Logger $logger
     ) {
         parent::__construct($context);
         $this->orderFactory = $orderFactory;
         $this->orderManagement = $orderManagement;
         $this->orderRepository = $orderRepository;
+        $this->logger = $logger;
     }
 
     /**
@@ -84,5 +86,23 @@ class OrderHelper extends AbstractHelper
         $this->orderRepository->save($order);
     }
 
+    /**
+     * Get an order collection
+     */
+    public function getOrderCollectionByCustomerId(int $customerId)
+    {
+        $this->logger->info('Get Order collection', []);
 
+        $orderCollection = $this->orderFactory->create($customerId)
+        ->addFieldToSelect('*')
+        ->addFieldToFilter('status', ['in' => [Order::STATE_COMPLETE, Order::STATE_PROCESSING]])
+        ->setOrder(
+            'created_at',
+            'desc'
+        )
+        ->setPageSize(10)
+        ->setCurPage(1);
+         $this->logger->info('Order collection', [$orderCollection]);
+         return $orderCollection;
+    }
 }

--- a/Helpers/OrderHelper.php
+++ b/Helpers/OrderHelper.php
@@ -2,13 +2,23 @@
 
 namespace Alma\MonthlyPayments\Helpers;
 
+use Magento\Catalog\Model\Category;
+use Magento\Catalog\Model\Product;
+use Magento\Catalog\Model\ResourceModel\Product\Collection as ProductCollection;
 use Magento\Framework\App\Helper\AbstractHelper;
 use Magento\Framework\App\Helper\Context;
+use Magento\Framework\Exception\LocalizedException;
+use Magento\Framework\Exception\NoSuchEntityException;
+use Magento\Framework\UrlInterface;
 use Magento\Sales\Api\Data\OrderInterface;
 use Magento\Sales\Api\OrderManagementInterface;
 use Magento\Sales\Api\OrderRepositoryInterface;
 use Magento\Sales\Model\Order;
+use Magento\Sales\Model\Order\Item;
 use Magento\Sales\Model\OrderFactory;
+use Magento\Sales\Model\ResourceModel\Order\Collection;
+use Magento\Sales\Model\ResourceModel\Order\CollectionFactory;
+use Magento\Store\Model\StoreManagerInterface;
 
 class OrderHelper extends AbstractHelper
 {
@@ -26,12 +36,19 @@ class OrderHelper extends AbstractHelper
      * @var OrderRepositoryInterface
      */
     private $orderRepository;
+    private $orderCollectionFactory;
+    private $logger;
+    private $productHelper;
+    private $storeManager;
 
     public function __construct(
         Context $context,
         OrderFactory $orderFactory,
+        CollectionFactory $orderCollectionFactory,
         OrderRepositoryInterface $orderRepository,
         OrderManagementInterface $orderManagement,
+        ProductHelper $productHelper,
+        StoreManagerInterface $storeManager,
         Logger $logger
     ) {
         parent::__construct($context);
@@ -39,6 +56,9 @@ class OrderHelper extends AbstractHelper
         $this->orderManagement = $orderManagement;
         $this->orderRepository = $orderRepository;
         $this->logger = $logger;
+        $this->productHelper = $productHelper;
+        $this->orderCollectionFactory = $orderCollectionFactory;
+        $this->storeManager = $storeManager;
     }
 
     /**
@@ -88,12 +108,12 @@ class OrderHelper extends AbstractHelper
 
     /**
      * Get an order collection
+     * @param int $customerId
+     * @return Collection
      */
-    public function getOrderCollectionByCustomerId(int $customerId)
+    public function getValidOrderCollectionByCustomerId(int $customerId): Collection
     {
-        $this->logger->info('Get Order collection', []);
-
-        $orderCollection = $this->orderFactory->create($customerId)
+        return $this->orderCollectionFactory->create($customerId)
         ->addFieldToSelect('*')
         ->addFieldToFilter('status', ['in' => [Order::STATE_COMPLETE, Order::STATE_PROCESSING]])
         ->setOrder(
@@ -102,7 +122,157 @@ class OrderHelper extends AbstractHelper
         )
         ->setPageSize(10)
         ->setCurPage(1);
-         $this->logger->info('Order collection', [$orderCollection]);
-         return $orderCollection;
+    }
+
+    /**
+     * Get payment methode by order
+     * @param Order $order
+     * @return string
+     */
+    public function getOrderPaymentMethodName(Order $order): string
+    {
+        return $order->getPayment()->getMethod();
+    }
+    /**
+     * Get payment methode by order;
+     * @param Order $order
+     * @return string
+     */
+    public function getOrderShippingMethodName(Order $order): string
+    {
+        return $order->getShippingMethod();
+    }
+    /**
+     * Parse order items for formatting
+     *
+     * @param array $dataProducts
+     * @return array
+     */
+    public function formatOrderItems(array $orderItems): array
+    {
+        $dataProducts = $this->formatOrderItemsForPaymentPayload($orderItems);
+        $formattedItems = [];
+
+        foreach ($dataProducts as $data) {
+            if (isset($data['item']) && isset($data['product']) && isset($data['categories'])) {
+                $formattedItems[] = $this->formatItem($data);
+            }
+        }
+        return $formattedItems;
+    }
+
+    /**
+     * @param array $orderItems
+     * @return mixed
+     * @throws LocalizedException
+     */
+    private function formatOrderItemsForPaymentPayload(array $orderItems)
+    {
+        $productsIds = $this->getProductsIds($orderItems);
+        $products = $this->productHelper->getProductsItems($productsIds);
+        $productsCategories = $this->productHelper->getProductsCategories($products);
+        $categories = $this->formatCategoriesInArray($productsCategories);
+        return $this->formatDataForPayload($orderItems, $products, $categories);
+    }
+    /**
+     * Get all non dummy productsIds for orderItems
+     *
+     * @param array $orderItems
+     * @return array
+     */
+    private function getProductsIds(array $orderItems): array
+    {
+        $productsIds = [];
+        foreach ($orderItems as $item) {
+            if (!$item->isDummy()) {
+                $productsIds[] = $item->getProductId();
+            }
+        }
+        return $productsIds;
+    }
+    /**
+     * Format categories collection in associative array ['entity_id' => Category]
+     *
+     * @param mixed $productsCategories
+     * @return array
+     */
+    private function formatCategoriesInArray($productsCategories): array
+    {
+        $categories = [];
+        foreach ($productsCategories as $category) {
+            /** @var Category $category */
+            $categories[$category->getEntityId()] = $category->getName();
+        }
+        return $categories;
+    }
+
+    /**
+     * @param array $orderItems
+     * @param ProductCollection $products
+     * @param array $categories
+     * @return array
+     */
+    private function formatDataForPayload(array $orderItems, ProductCollection $products, array $categories): array
+    {
+        $dataForCartItemPayload = [];
+        foreach ($orderItems as $item) {
+            /** @var Item $item */
+            if (!$item->isDummy()) {
+                $dataForCartItemPayload[$item->getProductId()]['item'] = $item;
+            }
+        }
+
+        foreach ($products as $product) {
+            /** @var Product $product */
+            $dataForCartItemPayload[$product->getEntityId()]['product'] = $product;
+            $productCategoriesNames = [];
+            foreach ($product->getCategoryIds() as $categoryId) {
+                if (isset($categories[$categoryId])) {
+                    $productCategoriesNames[] = $categories[$categoryId];
+                }
+            }
+            $dataForCartItemPayload[$product->getEntityId()]['categories'] = $productCategoriesNames;
+        }
+        return $dataForCartItemPayload;
+    }
+    /**
+     * Format array with order item, product, and categories for payment payload
+     *
+     * @param array $data
+     * @return array
+     */
+    private function formatItem(array $data): array
+    {
+        return [
+            'sku' => $data['item']->getSku(),
+            'vendor' => '',
+            'title' => $data['item']->getName(),
+            'variant_title' => $data['item']->getProductOptions()['simple_name'] ?? '',
+            'quantity' => (int) $data['item']->getQtyOrdered(),
+            'unit_price' => Functions::priceToCents($data['item']->getPriceInclTax()),
+            'line_price' => Functions::priceToCents($data['item']->getBaseRowTotalInclTax()),
+            'is_gift' => false,
+            'categories' => $data['categories'],
+            'url' => $data['product']->getProductUrl(),
+            'picture_url' => $this->getMediaUrl($data['product']->getImage()),
+            'requires_shipping' => !$data['item']->getIsVirtual(),
+            'taxes_included' => (bool) $data['item']->getTaxAmount()
+        ];
+    }
+    /**
+     * Return media url for a product
+     *
+     * @param string $path
+     * @return string
+     */
+    private function getMediaUrl(string $path): string
+    {
+        try {
+            return $this->storeManager->getStore()->getBaseUrl(UrlInterface::URL_TYPE_MEDIA) . 'catalog/product' . $path;
+        } catch (NoSuchEntityException $e) {
+            $this->logger->warning('Error in get media base url:', [$e->getMessage()]);
+        }
+
+        return '';
     }
 }

--- a/Helpers/OrderHelper.php
+++ b/Helpers/OrderHelper.php
@@ -175,7 +175,11 @@ class OrderHelper extends AbstractHelper
         $formattedItems = [];
 
         foreach ($dataProducts as $data) {
-            if (isset($data['item']) && isset($data['product']) && isset($data['categories'])) {
+            if (
+                isset($data['item'])
+                && isset($data['product'])
+                && isset($data['categories'])
+            ) {
                 $formattedItems[] = $this->formatItem($data);
             }
         }

--- a/Helpers/PaymentValidation.php
+++ b/Helpers/PaymentValidation.php
@@ -202,13 +202,11 @@ class PaymentValidation
             throw new AlmaPaymentValidationException($errorMessage);
         }
 
-        // Check that the Alma API has correctly registered the first installment as paid
-        $firstInstalment = $almaPayment->payment_plan[0];
-        if (!in_array($almaPayment->state, [AlmaPayment::STATE_IN_PROGRESS, AlmaPayment::STATE_PAID]) || $firstInstalment->state !== Instalment::STATE_PAID) {
+        // Check that the Alma API has correctly registered
+        if (!in_array($almaPayment->state, [AlmaPayment::STATE_IN_PROGRESS, AlmaPayment::STATE_PAID])) {
             $rejectionReason = __(
-                "Payment state incorrect (%1 & %2) for order %3",
+                "Payment state incorrect (%1) for order %3",
                 $almaPayment->state,
-                $firstInstalment->state,
                 $order->getIncrementId()
             );
 

--- a/Helpers/ProductHelper.php
+++ b/Helpers/ProductHelper.php
@@ -4,15 +4,16 @@ namespace Alma\MonthlyPayments\Helpers;
 
 use Magento\Catalog\Model\Product;
 use Magento\Catalog\Model\ResourceModel\Category\Collection as CategoryCollection;
+use Magento\Catalog\Model\ResourceModel\Category\CollectionFactory as CategoryCollectionFactory;
 use Magento\Catalog\Model\ResourceModel\Product\Collection;
-use Magento\Framework\Exception\LocalizedException;
+use Magento\Catalog\Model\ResourceModel\Product\CollectionFactory;
 
 class ProductHelper
 {
     /**
-     * @var Collection
+     * @var CollectionFactory
      */
-    private $productCollection;
+    private $productCollectionFactory;
     /**
      * @var Logger
      */
@@ -20,21 +21,21 @@ class ProductHelper
     /**
      * @var CategoryCollection
      */
-    private $categoryCollection;
+    private $categoryCollectionFactory;
 
     /**
      * @param Logger $logger
-     * @param Collection $productCollection
-     * @param CategoryCollection $categoryCollection
+     * @param CollectionFactory $productCollectionFactory
+     * @param CategoryCollectionFactory $categoryCollectionFactory
      */
     public function __construct(
-        Logger $logger,
-        Collection $productCollection,
-        CategoryCollection $categoryCollection
+        Logger             $logger,
+        CollectionFactory  $productCollectionFactory,
+        CategoryCollectionFactory $categoryCollectionFactory
     ) {
-        $this->productCollection = $productCollection;
+        $this->productCollectionFactory = $productCollectionFactory;
         $this->logger = $logger;
-        $this->categoryCollection = $categoryCollection;
+        $this->categoryCollectionFactory = $categoryCollectionFactory;
     }
 
     /**
@@ -45,7 +46,10 @@ class ProductHelper
      */
     public function getProductsItems(array $productIds): Collection
     {
-        return $this->productCollection->addAttributeToSelect('*')->addFieldToFilter('entity_id', ['in'=>$productIds]);
+        /** @var Collection $collection */
+        $collection = $this->productCollectionFactory->create();
+        $collection->addAttributeToSelect('*');
+        return $collection->addAttributeToFilter('entity_id', ['in'=>$productIds]);
     }
 
     /**
@@ -64,19 +68,16 @@ class ProductHelper
 
         return array_values($categoriesId);
     }
-
     /**
-     * Get a collection of categories with categories' ID array
+     * Generate categories collection with product a collection
      *
      * @param Collection $products
      * @return CategoryCollection
-     * @throws LocalizedException
      */
     public function getProductsCategories(Collection $products): CategoryCollection
     {
         $categoriesId = $this->getProductsCategoriesIds($products);
-        return $this->categoryCollection->addAttributeToSelect(['*'])->addFieldToFilter('entity_id', ['in'=>$categoriesId]);
 
+        return $this->categoryCollectionFactory->create()->addAttributeToSelect('*')->addFieldToFilter('entity_id', ['in'=>$categoriesId]);
     }
-
 }

--- a/Test/Unit/Gateway/Request/CartDataBuilderTest.php
+++ b/Test/Unit/Gateway/Request/CartDataBuilderTest.php
@@ -4,399 +4,51 @@ namespace Alma\MonthlyPayments\Test\Unit\Gateway\Request;
 
 use Alma\MonthlyPayments\Gateway\Request\CartDataBuilder;
 use Alma\MonthlyPayments\Helpers\Logger;
-use Alma\MonthlyPayments\Helpers\ProductHelper;
-use Magento\Catalog\Api\Data\CategoryInterface;
-use Magento\Catalog\Helper\Image;
-use Magento\Catalog\Model\Category;
-use Magento\Catalog\Model\Product;
-use Magento\Catalog\Model\ResourceModel\Category\Collection;
-use Magento\Catalog\Model\ResourceModel\Product\Collection as ProductCollectionAlias;
+use Alma\MonthlyPayments\Helpers\OrderHelper;
 use Magento\Payment\Gateway\Data\OrderAdapterInterface;
 use Magento\Payment\Gateway\Data\PaymentDataObjectInterface;
-use Magento\Sales\Model\Order\Item;
-use Magento\Store\Model\Store;
-use Magento\Store\Model\StoreManagerInterface;
 use PHPUnit\Framework\TestCase;
 
 class CartDataBuilderTest extends TestCase
 {
-    const MEDIA_BASE_URL = 'https://adobe-commerce-a-2-4-5.local.test/media/';
-    /**
-     * @var Logger
-     */
     private $logger;
+    private $orderHelper;
 
     public function setUp(): void
     {
         $this->logger = $this->createMock(Logger::class);
-
-        $this->imageHelper = $this->createMock(Image::class);
-        $this->imageHelper->method('init')->willReturn($this->imageHelper);
-        $this->imageHelper->method('getUrl')->willReturn('');
-
-        $storeInterface = $this->createMock(Store::class);
-        $storeInterface->method('getBaseUrl')->willReturn(self::MEDIA_BASE_URL);
-
-        $this->storeManagerInterface = $this->createMock(StoreManagerInterface::class);
-        $this->storeManagerInterface->method('getStore')->willReturn($storeInterface);
+        $this->orderHelper = $this->createMock(OrderHelper::class);
     }
     private function getConstructorDependency(): array
     {
         return [
-            $this->logger,
-            $this->storeManagerInterface,
-            $this->productHelper
-        ];
-    }
-    private function createCartDataBuilderTest(): CartDataBuilder
-    {
-        return new CartDataBuilder(...$this->getConstructorDependency());
+                $this->logger,
+                $this->orderHelper
+            ];
     }
 
-    /**
-     * @dataProvider CartPayloadDataProvider
-     *
-     * @return void
-     */
-    public function testBuild(array $dataItems, $expectedPayload):void
+    public function testBuildReturnFormatedPayload():void
     {
-        $products = [];
-        $items = [];
-        foreach ($dataItems as $data) {
-            $products[] = $this->productFactory(...$data);
-            $items[] = $this->itemFactory(...$data);
-        }
-
-
-        $productIterator = new \ArrayIterator($products);
-        $productCollectionMock = $this->createMock(ProductCollectionAlias::class);
-        $productCollectionMock->method('getIterator')->willReturn($productIterator);
-
-        $catGear = $this->createMock(Category::class);
-        $catGear->method('getEntityId')->willReturn('3');
-        $catGear->method('getName')->willReturn('Gear');
-        $catBag = $this->createMock(Category::class);
-        $catBag->method('getEntityId')->willReturn('4');
-        $catBag->method('getName')->willReturn('Bags');
-        $categoriesCollectionMock = $this->createMock(Collection::class);
-        $categoryIterator = new \ArrayIterator([$catGear,$catBag]);
-        $categoriesCollectionMock->method('getIterator')->willReturn($categoryIterator);
-
-        $this->productHelper = $this->createMock(ProductHelper::class);
-        $this->productHelper->method('getProductsItems')->willReturn($productCollectionMock);
-        $this->productHelper->method('getProductsCategories')->willReturn($categoriesCollectionMock);
-
-        $cartDataBuilder = $this->createCartDataBuilderTest();
+        $this->orderHelper->method('formatOrderItems')->willReturn([]);
         $this->assertEquals(
-            $expectedPayload,
-            $cartDataBuilder->build(
-                ["payment" => $this->createPaymentDataObject($items)]
-            )
-        );
+            [
+                "cart" => [
+                    'items' => []
+                ]
+            ],
+            $this->createCartDataBuilderTest()->build(["payment" => $this->createPaymentDataObject()]));
     }
-
-    public function cartPayloadDataProvider():array
-    {
-        $simple1 = [
-            '1',
-            'base-01',
-            'Simple product 1',
-            2.0,
-            22.30,
-            44.60,
-            0,
-            2.10
-        ];
-        $formattedSimple1 = $this->formattedItemFactory(
-            'base-01',
-            'Simple product 1',
-            '',
-            2,
-            2230,
-            4460,
-            false,
-            true
-        );
-        $simple2 = [
-            '2',
-            'base-02',
-            'Simple product 2',
-            1.0,
-            24.30,
-            24.30,
-            0,
-            1.10
-        ];
-        $formattedSimple2 = $this->formattedItemFactory(
-            'base-02',
-            'Simple product 2',
-            '',
-            1,
-            2430,
-            2430,
-            false,
-            true
-        );
-        $simpleWithoutCategory = [
-            '3',
-            'base-02',
-            'Simple product 2',
-            1.0,
-            24.30,
-            24.30,
-            0,
-            1.10,
-            []
-        ];
-        $formattedSimpleWithoutCategory = $this->formattedItemFactory(
-            'base-02',
-            'Simple product 2',
-            '',
-            1,
-            2430,
-            2430,
-            false,
-            true,
-            []
-        );
-        $virtualProduct1 = [
-            '4',
-            'base-02',
-            'Simple product 2',
-            1.0,
-            24.30,
-            24.30,
-            1,
-            1.10
-        ];
-        $formattedVirtualProduct1 = $this->formattedItemFactory(
-            'base-02',
-            'Simple product 2',
-            '',
-            1,
-            2430,
-            2430,
-            true,
-            true
-        );
-        $simpleWithoutTax = [
-            '5',
-            'base-01',
-            'Simple product 1',
-            2.0,
-            22.30,
-            44.60,
-            0,
-            0
-        ];
-        $formattedSimpleWithoutTax = $this->formattedItemFactory(
-            'base-01',
-            'Simple product 1',
-            '',
-            2,
-            2230,
-            4460,
-            false,
-            false
-        );
-
-        $dummyConfigurableProduct = [
-            '6',
-            'config-dummy-01',
-            'Configurable dummy product 1',
-            1.0,
-            0.0,
-            0.0,
-            0,
-            0,
-            ['3','4'],
-            true
-        ];
-        $configurableProduct = [
-            '7',
-            'config-01',
-            'Configurable product 1',
-            1.0,
-            24.30,
-            24.30,
-            0,
-            1.2,
-            ['3','4'],
-            false,
-            ['simple_name' => 'Configurable product 1 - with variation']
-        ];
-        $formattedConfigurableProduct = $this->formattedItemFactory(
-            'config-01',
-            'Configurable product 1',
-            'Configurable product 1 - with variation',
-            1,
-            2430,
-            2430,
-            false,
-            true
-        );
-        return [
-            '1 simple product' => [
-                'products' =>  [$simple1],
-                'expected_payload' => [
-                    'cart' => [
-                        'items' => [
-                            $formattedSimple1
-                        ]
-                    ]
-                ]
-            ],
-            '2 simple products' => [
-                'products' =>  [$simple1, $simple2],
-                'expected_payload' => [
-                    'cart' => [
-                        'items' => [
-                            $formattedSimple1 ,$formattedSimple2
-                        ]
-                    ]
-                ]
-            ],
-            '1 simple product without category' => [
-                'products' =>  [$simpleWithoutCategory],
-                'expected_payload' => [
-                    'cart' => [
-                        'items' => [
-                            $formattedSimpleWithoutCategory
-                        ]
-                    ]
-                ]
-            ],
-            '1 virtual product' => [
-                'products' =>  [$virtualProduct1],
-                'expected_payload' => [
-                    'cart' => [
-                        'items' => [
-                            $formattedVirtualProduct1
-                        ]
-                    ]
-                ]
-            ],
-            '1 simple without tax' => [
-                'products' =>  [$simpleWithoutTax],
-                'expected_payload' => [
-                    'cart' => [
-                        'items' => [
-                            $formattedSimpleWithoutTax
-                        ]
-                    ]
-                ]
-            ],
-            '1 configurable product with dummy item' => [
-                'products' =>  [$configurableProduct, $dummyConfigurableProduct],
-                'expected_payload' => [
-                    'cart' => [
-                        'items' => [
-                            $formattedConfigurableProduct
-                        ]
-                    ]
-                ]
-            ],
-            '1 configurable product with dummy item and 1 simple' => [
-                'products' =>  [
-                        $configurableProduct,
-                        $dummyConfigurableProduct,
-                        $simple1
-                ],
-                'expected_payload' => [
-                    'cart' => [
-                        'items' => [
-                            $formattedConfigurableProduct,
-                            $formattedSimple1
-                        ]
-                    ]
-                ]
-            ],
-        ];
-    }
-
-    private function createPaymentDataObject(array $items):PaymentDataObjectInterface
+    private function createPaymentDataObject():PaymentDataObjectInterface
     {
         $orderAdapter = $this->createMock(OrderAdapterInterface::class);
-        $orderAdapter->method('getItems')->willReturn($items);
+        $orderAdapter->method('getItems')->willReturn([]);
 
         $paymentDataObject = $this->createMock(PaymentDataObjectInterface::class);
         $paymentDataObject->method('getOrder')->willReturn($orderAdapter);
         return $paymentDataObject;
     }
-
-    private function itemFactory(
-        string $pid,
-        string $sku,
-        string $name,
-        float $qty,
-        float $price,
-        float $rowPrice,
-        bool $isVirtual,
-        float $taxAmount,
-        array $categories = ['3','4'],
-        bool $dummy = false,
-        array $productOptions= []
-    ):Item {
-        $item = $this->createMock(Item::class);
-        $item->method('getProductId')->willReturn($pid);
-        $item->method('getSku')->willReturn($sku);
-        $item->method('getName')->willReturn($name);
-        $item->method('getProductOptions')->willReturn($productOptions);
-        $item->method('getQtyOrdered')->willReturn($qty);
-        $item->method('getPriceInclTax')->willReturn($price);
-        $item->method('getBaseRowTotalInclTax')->willReturn($rowPrice);
-        $item->method('getIsVirtual')->willReturn($isVirtual);
-        $item->method('getTaxAmount')->willReturn($taxAmount);
-        $item->method('isDummy')->willReturn($dummy);
-        return $item;
-    }
-    private function productFactory(
-        string $pid,
-        string $sku,
-        string $name,
-        float $qty,
-        float $price,
-        float $rowPrice,
-        bool $isVirtual,
-        float $taxAmount,
-        array $categories = ['3','4'],
-        bool $dummy = false,
-        array $productOptions= []
-    ):Product {
-        $product = $this->createMock(Product::class);
-        $product->method('getEntityId')->willReturn($pid);
-        $product->method('getName')->willReturn($name);
-        $product->method('getCategoryIds')->willReturn($categories);
-        $product->method('getProductUrl')->willReturn('https://adobe-commerce-a-2-4-5.local.test/fusion-backpack.html');
-        $product->method('getImage')->willReturn('/w/b/wb04-blue-0.jpg');
-        return $product;
-    }
-
-    private function formattedItemFactory(
-        string $sku,
-        string $name,
-        string $variantName,
-        int $qty,
-        int $price,
-        int $rowPrice,
-        bool $isVirtual,
-        bool $taxAmount,
-        array $categories =  ['Gear','Bags']
-    ):array {
-        return [
-            'sku' => $sku,
-            'vendor' => '',
-            'title' => $name,
-            'variant_title' => $variantName,
-            'quantity' => $qty,
-            'unit_price' => $price,
-            'line_price' => $rowPrice,
-            'is_gift' => false,
-            'categories' => $categories,
-            'url' => 'https://adobe-commerce-a-2-4-5.local.test/fusion-backpack.html',
-            'picture_url' => self::MEDIA_BASE_URL . 'catalog/product' . '/w/b/wb04-blue-0.jpg',
-            'requires_shipping' => !$isVirtual,
-            'taxes_included' => $taxAmount
-        ];
+    private function createCartDataBuilderTest(): CartDataBuilder
+    {
+        return new CartDataBuilder(...$this->getConstructorDependency());
     }
 }

--- a/Test/Unit/Gateway/Request/OrderDataBuilderTest.php
+++ b/Test/Unit/Gateway/Request/OrderDataBuilderTest.php
@@ -17,11 +17,17 @@ class OrderDataBuilderTest extends TestCase
      */
     private $logger;
 
+    /**
+     * @return void
+     */
     public function setUp(): void
     {
         $this->logger = $this->createMock(Logger::class);
     }
 
+    /**
+     * @return Logger[]
+     */
     private function getConstructorDependency(): array
     {
         return [
@@ -29,11 +35,19 @@ class OrderDataBuilderTest extends TestCase
         ];
     }
 
+    /**
+     * @return OrderDataBuilder
+     */
     private function createOrderDataBuilderTest(): OrderDataBuilder
     {
         return new OrderDataBuilder(...$this->getConstructorDependency());
     }
 
+    /**
+     * @return void
+     * @throws \Magento\Framework\Exception\LocalizedException
+     * @throws \Magento\Framework\Exception\NoSuchEntityException
+     */
     public function testOrderPayload():void
     {
         $paymentDataBuilder = $this->createOrderDataBuilderTest()->build($this->mockBuildSubject());

--- a/Test/Unit/Gateway/Request/OrderDataBuilderTest.php
+++ b/Test/Unit/Gateway/Request/OrderDataBuilderTest.php
@@ -2,18 +2,10 @@
 
 namespace Alma\MonthlyPayments\Test\Unit\Gateway\Request;
 
-use Alma\MonthlyPayments\Gateway\Request\CartDataBuilder;
 use Alma\MonthlyPayments\Gateway\Request\OrderDataBuilder;
 use Alma\MonthlyPayments\Helpers\Logger;
-use Alma\MonthlyPayments\Helpers\ProductHelper;
-use Magento\Catalog\Model\Category;
-use Magento\Catalog\Model\Product;
-use Magento\Catalog\Model\ResourceModel\Category\Collection;
-use Magento\Catalog\Model\ResourceModel\Product\Collection as ProductCollectionAlias;
 use Magento\Payment\Gateway\Data\OrderAdapterInterface;
 use Magento\Payment\Gateway\Data\PaymentDataObject;
-use Magento\Payment\Gateway\Data\PaymentDataObjectInterface;
-use Magento\Sales\Model\Order\Item;
 use PHPUnit\Framework\TestCase;
 
 class OrderDataBuilderTest extends TestCase
@@ -44,18 +36,14 @@ class OrderDataBuilderTest extends TestCase
 
     public function testOrderPayload():void
     {
-        $orderInterfaceMock = $this->createMock(OrderAdapterInterface::class);
-        $orderInterfaceMock->expects($this->once())->method('getOrderIncrementId')->willReturn(self::INCREMENT_ID);
-
-        $paymentDataObjectMock = $this->createMock(PaymentDataObject::class);
-        $paymentDataObjectMock->expects($this->once())->method('getOrder')->willReturn($orderInterfaceMock);
-        $buildSubjectMock = ['payment' => $paymentDataObjectMock];
-
-        $paymentDataBuilder = $this->createOrderDataBuilderTest()->build($buildSubjectMock);
+        $paymentDataBuilder = $this->createOrderDataBuilderTest()->build($this->mockBuildSubject());
         $this->assertEquals($this->responseBuilder(), $paymentDataBuilder);
-
     }
 
+    /**
+     * @param string $incrementID
+     * @return array
+     */
     private function responseBuilder():array
     {
         return [
@@ -63,5 +51,18 @@ class OrderDataBuilderTest extends TestCase
                 'merchant_reference' => self::INCREMENT_ID
             ]
         ];
+    }
+
+    /**
+     * @return array
+     */
+    private function mockBuildSubject():array
+    {
+        $orderInterfaceMock = $this->createMock(OrderAdapterInterface::class);
+        $orderInterfaceMock->expects($this->once())->method('getOrderIncrementId')->willReturn(self::INCREMENT_ID);
+
+        $paymentDataObjectMock = $this->createMock(PaymentDataObject::class);
+        $paymentDataObjectMock->expects($this->once())->method('getOrder')->willReturn($orderInterfaceMock);
+        return ['payment' => $paymentDataObjectMock];
     }
 }

--- a/Test/Unit/Gateway/Request/OrderDataBuilderTest.php
+++ b/Test/Unit/Gateway/Request/OrderDataBuilderTest.php
@@ -1,0 +1,67 @@
+<?php
+
+namespace Alma\MonthlyPayments\Test\Unit\Gateway\Request;
+
+use Alma\MonthlyPayments\Gateway\Request\CartDataBuilder;
+use Alma\MonthlyPayments\Gateway\Request\OrderDataBuilder;
+use Alma\MonthlyPayments\Helpers\Logger;
+use Alma\MonthlyPayments\Helpers\ProductHelper;
+use Magento\Catalog\Model\Category;
+use Magento\Catalog\Model\Product;
+use Magento\Catalog\Model\ResourceModel\Category\Collection;
+use Magento\Catalog\Model\ResourceModel\Product\Collection as ProductCollectionAlias;
+use Magento\Payment\Gateway\Data\OrderAdapterInterface;
+use Magento\Payment\Gateway\Data\PaymentDataObject;
+use Magento\Payment\Gateway\Data\PaymentDataObjectInterface;
+use Magento\Sales\Model\Order\Item;
+use PHPUnit\Framework\TestCase;
+
+class OrderDataBuilderTest extends TestCase
+{
+    const INCREMENT_ID =  '100001';
+
+    /**
+     * @var Logger
+     */
+    private $logger;
+
+    public function setUp(): void
+    {
+        $this->logger = $this->createMock(Logger::class);
+    }
+
+    private function getConstructorDependency(): array
+    {
+        return [
+            $this->logger,
+        ];
+    }
+
+    private function createOrderDataBuilderTest(): OrderDataBuilder
+    {
+        return new OrderDataBuilder(...$this->getConstructorDependency());
+    }
+
+    public function testOrderPayload():void
+    {
+        $orderInterfaceMock = $this->createMock(OrderAdapterInterface::class);
+        $orderInterfaceMock->expects($this->once())->method('getOrderIncrementId')->willReturn(self::INCREMENT_ID);
+
+        $paymentDataObjectMock = $this->createMock(PaymentDataObject::class);
+        $paymentDataObjectMock->expects($this->once())->method('getOrder')->willReturn($orderInterfaceMock);
+        $buildSubjectMock = ['payment' => $paymentDataObjectMock];
+
+        $paymentDataBuilder = $this->createOrderDataBuilderTest()->build($buildSubjectMock);
+        $this->assertEquals($this->responseBuilder(), $paymentDataBuilder);
+
+    }
+
+    private function responseBuilder():array
+    {
+        return [
+            'order' => [
+                'merchant_reference' => self::INCREMENT_ID
+            ]
+        ];
+    }
+}

--- a/Test/Unit/Gateway/Request/WebsiteCustomerDetailsDataBuilderTest.php
+++ b/Test/Unit/Gateway/Request/WebsiteCustomerDetailsDataBuilderTest.php
@@ -9,6 +9,8 @@ use Magento\Framework\Exception\LocalizedException;
 use Magento\Framework\Exception\NoSuchEntityException;
 use Magento\Payment\Gateway\Data\OrderAdapterInterface;
 use Magento\Payment\Gateway\Data\PaymentDataObject;
+use Magento\Reports\Model\ResourceModel\Customer\Orders\Collection;
+use Magento\Sales\Model\Order;
 use PHPUnit\Framework\TestCase;
 
 class WebsiteCustomerDetailsDataBuilderTest extends TestCase
@@ -51,27 +53,31 @@ class WebsiteCustomerDetailsDataBuilderTest extends TestCase
     /**
      * @dataProvider payloadDataProvider
      * @param array $customer
-     * @param array $orders
+     * @param Collection $orderCollection
      * @param array $previousOrders
      * @return void
      * @throws LocalizedException
      * @throws NoSuchEntityException
      */
-    public function testWebsiteCustomerDetailsPayload(array $customer, array $orders, array $previousOrders):void
+    public function testWebsiteCustomerDetailsPayload(array $customer, Collection $orderCollection, array $previousOrders, bool $isGuest):void
     {
+        //mock orders
+        $this->orderHelper->method('getValidOrderCollectionByCustomerId')->willReturn($orderCollection);
         $paymentDataBuilder = $this->createWebsiteCustomerDetailsDataBuilderTest()
             ->build($this->mockBuildSubject($customer));
-        $this->assertEquals($this->responseBuilder($previousOrders), $paymentDataBuilder);
+        $this->assertEquals($this->responseBuilder($previousOrders, $isGuest), $paymentDataBuilder);
     }
 
     /**
-     * @param $previousOrders
+     * @param array $previousOrders
+     * @param bool $isGuest
      * @return array
      */
-    private function responseBuilder($previousOrders):array
+    private function responseBuilder(array $previousOrders,bool $isGuest):array
     {
         return [
             'website_customer_details' => [
+                'is_guest' => $isGuest,
                 'previous_orders' => $previousOrders
             ]
         ];
@@ -101,16 +107,69 @@ class WebsiteCustomerDetailsDataBuilderTest extends TestCase
                 'customer' => [
                     'id' => null
                 ],
-                'orders' => [],
-                'previousOrders' => []
+                'orderCollection' => $this->mockOrderCollectionFactory(),
+                'previousOrders' => [],
+                'isGuest' => true
             ],
-            'Previous order must be an empty array for identified customer' => [
+            'Previous order must be an empty array for identified customer without previous order' => [
                 'customer' => [
                     'id' => 1
                 ],
-                'orders' => [],
-                'previousOrders' => []
+                'orderCollection' => $this->mockOrderCollectionFactory(),
+                'previousOrders' => [],
+                'isGuest' => false
+            ],
+            'Previous order must be an array for identified customer with previous order' => [
+                'customer' => [
+                    'id' => 1
+                ],
+                'orderCollection' => $this->mockOrderCollectionFactory(
+                    [
+                        $this->mockOrderFactory(123),
+                        $this->mockOrderFactory(223)
+                    ]
+                ),
+                'previousOrders' => [
+                    [
+                        "purchase_amount"=> 12300,
+                        "created"=> 1687513900,
+                        "items" => [],
+                        "payment_method" =>'',
+                        "shipping_method" => ''
+                    ],
+                    [
+                        "purchase_amount"=> 22300,
+                        "created"=> 1687513900,
+                        "items" => [],
+                        "payment_method" =>'',
+                        "shipping_method" => ''
+                    ]
+                ],
+                'isGuest' => false
             ],
         ];
+    }
+
+    /**
+     * Get a mock order collection
+     *
+     * @param array $orders
+     * @return Collection
+     */
+    private function mockOrderCollectionFactory(array $orders = []): Collection
+    {
+        $emptyIterator = new \ArrayIterator($orders);
+        $emptyCollection = $this->createPartialMock(Collection::class, ['getIterator']);
+        $emptyCollection->method('getIterator')->willReturn($emptyIterator);
+        return $emptyCollection;
+    }
+
+    private function mockOrderFactory($total): Order
+    {
+        $order = $this->createMock(Order::class);
+        $order->method('getGrandTotal')->willReturn($total);
+        $order->method('getCreatedAt')->willReturn('Fri, 23 Jun 2023 09:51:40 GMT');
+        $order->method('getItems')->willReturn([]);
+        return $order;
     }
 }

--- a/Test/Unit/Gateway/Request/WebsiteCustomerDetailsDataBuilderTest.php
+++ b/Test/Unit/Gateway/Request/WebsiteCustomerDetailsDataBuilderTest.php
@@ -1,0 +1,116 @@
+<?php
+
+namespace Alma\MonthlyPayments\Test\Unit\Gateway\Request;
+
+use Alma\MonthlyPayments\Gateway\Request\WebsiteCustomerDetailsDataBuilder;
+use Alma\MonthlyPayments\Helpers\Logger;
+use Alma\MonthlyPayments\Helpers\OrderHelper;
+use Magento\Framework\Exception\LocalizedException;
+use Magento\Framework\Exception\NoSuchEntityException;
+use Magento\Payment\Gateway\Data\OrderAdapterInterface;
+use Magento\Payment\Gateway\Data\PaymentDataObject;
+use PHPUnit\Framework\TestCase;
+
+class WebsiteCustomerDetailsDataBuilderTest extends TestCase
+{
+    const INCREMENT_ID =  '100001';
+
+    /**
+     * @var Logger
+     */
+    private $logger;
+
+    /**
+     * @return void
+     */
+    public function setUp(): void
+    {
+        $this->logger = $this->createMock(Logger::class);
+        $this->orderHelper = $this->createMock(OrderHelper::class);
+    }
+
+    /**
+     * @return Logger[]
+     */
+    private function getConstructorDependency(): array
+    {
+        return [
+            $this->logger,
+            $this->orderHelper
+        ];
+    }
+
+    /**
+     * @return WebsiteCustomerDetailsDataBuilder
+     */
+    private function createWebsiteCustomerDetailsDataBuilderTest(): WebsiteCustomerDetailsDataBuilder
+    {
+        return new WebsiteCustomerDetailsDataBuilder(...$this->getConstructorDependency());
+    }
+
+    /**
+     * @dataProvider payloadDataProvider
+     * @param array $customer
+     * @param array $orders
+     * @param array $previousOrders
+     * @return void
+     * @throws LocalizedException
+     * @throws NoSuchEntityException
+     */
+    public function testWebsiteCustomerDetailsPayload(array $customer, array $orders, array $previousOrders):void
+    {
+        $paymentDataBuilder = $this->createWebsiteCustomerDetailsDataBuilderTest()
+            ->build($this->mockBuildSubject($customer));
+        $this->assertEquals($this->responseBuilder($previousOrders), $paymentDataBuilder);
+    }
+
+    /**
+     * @param $previousOrders
+     * @return array
+     */
+    private function responseBuilder($previousOrders):array
+    {
+        return [
+            'website_customer_details' => [
+                'previous_orders' => $previousOrders
+            ]
+        ];
+    }
+
+    /**
+     * @param  array $customer
+     * @return array
+     */
+    private function mockBuildSubject(array $customer):array
+    {
+        $orderInterfaceMock = $this->createMock(OrderAdapterInterface::class);
+        $orderInterfaceMock
+            ->method('getCustomerId')
+            ->willReturn($customer['id']);
+        $paymentDataObjectMock = $this->createMock(PaymentDataObject::class);
+        $paymentDataObjectMock
+            ->method('getOrder')
+            ->willReturn($orderInterfaceMock);
+        return ['payment' => $paymentDataObjectMock];
+    }
+
+    public function payloadDataProvider():array
+    {
+        return [
+            'Previous order must be an empty array for guest' => [
+                'customer' => [
+                    'id' => null
+                ],
+                'orders' => [],
+                'previousOrders' => []
+            ],
+            'Previous order must be an empty array for identified customer' => [
+                'customer' => [
+                    'id' => 1
+                ],
+                'orders' => [],
+                'previousOrders' => []
+            ],
+        ];
+    }
+}

--- a/Test/Unit/Gateway/Request/WebsiteCustomerDetailsDataBuilderTest.php
+++ b/Test/Unit/Gateway/Request/WebsiteCustomerDetailsDataBuilderTest.php
@@ -5,8 +5,6 @@ namespace Alma\MonthlyPayments\Test\Unit\Gateway\Request;
 use Alma\MonthlyPayments\Gateway\Request\WebsiteCustomerDetailsDataBuilder;
 use Alma\MonthlyPayments\Helpers\Logger;
 use Alma\MonthlyPayments\Helpers\OrderHelper;
-use Magento\Framework\Exception\LocalizedException;
-use Magento\Framework\Exception\NoSuchEntityException;
 use Magento\Payment\Gateway\Data\OrderAdapterInterface;
 use Magento\Payment\Gateway\Data\PaymentDataObject;
 use Magento\Reports\Model\ResourceModel\Customer\Orders\Collection;
@@ -55,9 +53,8 @@ class WebsiteCustomerDetailsDataBuilderTest extends TestCase
      * @param array $customer
      * @param Collection $orderCollection
      * @param array $previousOrders
+     * @param bool $isGuest
      * @return void
-     * @throws LocalizedException
-     * @throws NoSuchEntityException
      */
     public function testWebsiteCustomerDetailsPayload(array $customer, Collection $orderCollection, array $previousOrders, bool $isGuest):void
     {
@@ -73,7 +70,7 @@ class WebsiteCustomerDetailsDataBuilderTest extends TestCase
      * @param bool $isGuest
      * @return array
      */
-    private function responseBuilder(array $previousOrders,bool $isGuest):array
+    private function responseBuilder(array $previousOrders, bool $isGuest):array
     {
         return [
             'website_customer_details' => [

--- a/Test/Unit/Helpers/OrderHelperTest.php
+++ b/Test/Unit/Helpers/OrderHelperTest.php
@@ -345,16 +345,6 @@ class OrderHelperTest extends TestCase
         ];
     }
 
-    private function createPaymentDataObject(array $items):PaymentDataObjectInterface
-    {
-        $orderAdapter = $this->createMock(OrderAdapterInterface::class);
-        $orderAdapter->method('getItems')->willReturn($items);
-
-        $paymentDataObject = $this->createMock(PaymentDataObjectInterface::class);
-        $paymentDataObject->method('getOrder')->willReturn($orderAdapter);
-        return $paymentDataObject;
-    }
-
     private function itemFactory(
         string $pid,
         string $sku,
@@ -364,7 +354,6 @@ class OrderHelperTest extends TestCase
         float $rowPrice,
         bool $isVirtual,
         float $taxAmount,
-        array $categories = ['3','4'],
         bool $dummy = false,
         array $productOptions= []
     ):Item {
@@ -383,16 +372,8 @@ class OrderHelperTest extends TestCase
     }
     private function productFactory(
         string $pid,
-        string $sku,
         string $name,
-        float $qty,
-        float $price,
-        float $rowPrice,
-        bool $isVirtual,
-        float $taxAmount,
         array $categories = ['3','4'],
-        bool $dummy = false,
-        array $productOptions= []
     ):Product {
         $product = $this->createMock(Product::class);
         $product->method('getEntityId')->willReturn($pid);
@@ -425,7 +406,7 @@ class OrderHelperTest extends TestCase
             'is_gift' => false,
             'categories' => $categories,
             'url' => 'https://adobe-commerce-a-2-4-5.local.test/fusion-backpack.html',
-            'picture_url' => self::MEDIA_BASE_URL . 'catalog/product' . '/w/b/wb04-blue-0.jpg',
+            'picture_url' => self::MEDIA_BASE_URL . 'catalog/product/w/b/wb04-blue-0.jpg',
             'requires_shipping' => !$isVirtual,
             'taxes_included' => $taxAmount
         ];

--- a/Test/Unit/Helpers/OrderHelperTest.php
+++ b/Test/Unit/Helpers/OrderHelperTest.php
@@ -2,18 +2,32 @@
 
 namespace Alma\MonthlyPayments\Test\Unit\Helpers;
 
+use Alma\MonthlyPayments\Helpers\Logger;
 use Alma\MonthlyPayments\Helpers\OrderHelper;
+use Alma\MonthlyPayments\Helpers\ProductHelper;
+use Magento\Catalog\Model\Category;
+use Magento\Catalog\Model\Product;
+use Magento\Catalog\Model\ResourceModel\Category\Collection;
+use Magento\Catalog\Model\ResourceModel\Product\Collection as ProductCollectionAlias;
 use Magento\Framework\App\Helper\AbstractHelper;
+use Magento\Framework\App\Helper\Context;
+use Magento\Payment\Gateway\Data\OrderAdapterInterface;
+use Magento\Payment\Gateway\Data\PaymentDataObjectInterface;
 use Magento\Sales\Api\OrderManagementInterface;
 use Magento\Sales\Api\OrderRepositoryInterface;
 use Magento\Sales\Model\Order;
+use Magento\Sales\Model\Order\Item;
 use Magento\Sales\Model\OrderFactory;
+use Magento\Sales\Model\ResourceModel\Order\CollectionFactory;
+use Magento\Store\Model\Store;
+use Magento\Store\Model\StoreManager;
+use Magento\Store\Model\StoreManagerInterface;
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
-use Magento\Framework\App\Helper\Context;
 
 class OrderHelperTest extends TestCase
 {
+    const MEDIA_BASE_URL = 'https://adobe-commerce-a-2-4-5.local.test/media/';
     /**
      * @var OrderRepositoryInterface|MockObject
      */
@@ -22,13 +36,41 @@ class OrderHelperTest extends TestCase
      * @var OrderFactory|MockObject
      */
     private $orderFactory;
+    private $logger;
 
     protected function setUp(): void
     {
         $this->contextMock = $this->createMock(Context::class);
         $this->orderFactory = $this->createMock(OrderFactory::class);
+        $this->orderCollectionFactory = $this->createMock(CollectionFactory::class);
         $this->orderRepository = $this->createMock(OrderRepositoryInterface::class);
         $this->orderManagement = $this->createMock(OrderManagementInterface::class);
+        $this->productHelper = $this->createMock(ProductHelper::class);
+        $this->storeManager = $this->createMock(StoreManager::class);
+        $this->logger = $this->createMock(Logger::class);
+
+        $storeInterface = $this->createMock(Store::class);
+        $storeInterface->method('getBaseUrl')->willReturn(self::MEDIA_BASE_URL);
+
+        $this->storeManagerInterface = $this->createMock(StoreManagerInterface::class);
+        $this->storeManagerInterface->method('getStore')->willReturn($storeInterface);
+    }
+    private function getConstructorDependency(): array
+    {
+        return [
+            $this->contextMock,
+            $this->orderFactory,
+            $this->orderCollectionFactory,
+            $this->orderRepository,
+            $this->orderManagement,
+            $this->productHelper,
+            $this->storeManagerInterface,
+            $this->logger
+        ];
+    }
+    private function createNewOrderHelper(): OrderHelper
+    {
+        return new OrderHelper(...$this->getConstructorDependency());
     }
 
     public function testInstanceConfigHelper()
@@ -71,10 +113,321 @@ class OrderHelperTest extends TestCase
         $orderHelper = $this->createNewOrderHelper();
         $orderHelper->save($mockOrder);
     }
-
-    private function createNewOrderHelper(): OrderHelper
+    /**
+     * @dataProvider CartPayloadDataProvider
+     *
+     * @return void
+     */
+    public function testBuild(array $dataItems, $expectedPayload):void
     {
-        return new OrderHelper($this->contextMock, $this->orderFactory, $this->orderRepository, $this->orderManagement);
+        $products = [];
+        $items = [];
+        foreach ($dataItems as $data) {
+            $products[] = $this->productFactory(...$data);
+            $items[] = $this->itemFactory(...$data);
+        }
+
+        $productIterator = new \ArrayIterator($products);
+        $productCollectionMock = $this->createMock(ProductCollectionAlias::class);
+        $productCollectionMock->method('getIterator')->willReturn($productIterator);
+
+        $catGear = $this->createMock(Category::class);
+        $catGear->method('getEntityId')->willReturn('3');
+        $catGear->method('getName')->willReturn('Gear');
+        $catBag = $this->createMock(Category::class);
+        $catBag->method('getEntityId')->willReturn('4');
+        $catBag->method('getName')->willReturn('Bags');
+        $categoriesCollectionMock = $this->createMock(Collection::class);
+        $categoryIterator = new \ArrayIterator([$catGear,$catBag]);
+        $categoriesCollectionMock->method('getIterator')->willReturn($categoryIterator);
+
+        $this->productHelper = $this->createMock(ProductHelper::class);
+        $this->productHelper->method('getProductsItems')->willReturn($productCollectionMock);
+        $this->productHelper->method('getProductsCategories')->willReturn($categoriesCollectionMock);
+
+        $cartDataBuilder = $this->createNewOrderHelper();
+        $this->assertEquals(
+            $expectedPayload,
+            $cartDataBuilder->formatOrderItems(
+                $items
+            )
+        );
     }
 
+    public function cartPayloadDataProvider():array
+    {
+        $simple1 = [
+            '1',
+            'base-01',
+            'Simple product 1',
+            2.0,
+            22.30,
+            44.60,
+            0,
+            2.10
+        ];
+        $formattedSimple1 = $this->formattedItemFactory(
+            'base-01',
+            'Simple product 1',
+            '',
+            2,
+            2230,
+            4460,
+            false,
+            true
+        );
+        $simple2 = [
+            '2',
+            'base-02',
+            'Simple product 2',
+            1.0,
+            24.30,
+            24.30,
+            0,
+            1.10
+        ];
+        $formattedSimple2 = $this->formattedItemFactory(
+            'base-02',
+            'Simple product 2',
+            '',
+            1,
+            2430,
+            2430,
+            false,
+            true
+        );
+        $simpleWithoutCategory = [
+            '3',
+            'base-02',
+            'Simple product 2',
+            1.0,
+            24.30,
+            24.30,
+            0,
+            1.10,
+            []
+        ];
+        $formattedSimpleWithoutCategory = $this->formattedItemFactory(
+            'base-02',
+            'Simple product 2',
+            '',
+            1,
+            2430,
+            2430,
+            false,
+            true,
+            []
+        );
+        $virtualProduct1 = [
+            '4',
+            'base-02',
+            'Simple product 2',
+            1.0,
+            24.30,
+            24.30,
+            1,
+            1.10
+        ];
+        $formattedVirtualProduct1 = $this->formattedItemFactory(
+            'base-02',
+            'Simple product 2',
+            '',
+            1,
+            2430,
+            2430,
+            true,
+            true
+        );
+        $simpleWithoutTax = [
+            '5',
+            'base-01',
+            'Simple product 1',
+            2.0,
+            22.30,
+            44.60,
+            0,
+            0
+        ];
+        $formattedSimpleWithoutTax = $this->formattedItemFactory(
+            'base-01',
+            'Simple product 1',
+            '',
+            2,
+            2230,
+            4460,
+            false,
+            false
+        );
+
+        $dummyConfigurableProduct = [
+            '6',
+            'config-dummy-01',
+            'Configurable dummy product 1',
+            1.0,
+            0.0,
+            0.0,
+            0,
+            0,
+            ['3','4'],
+            true
+        ];
+        $configurableProduct = [
+            '7',
+            'config-01',
+            'Configurable product 1',
+            1.0,
+            24.30,
+            24.30,
+            0,
+            1.2,
+            ['3','4'],
+            false,
+            ['simple_name' => 'Configurable product 1 - with variation']
+        ];
+        $formattedConfigurableProduct = $this->formattedItemFactory(
+            'config-01',
+            'Configurable product 1',
+            'Configurable product 1 - with variation',
+            1,
+            2430,
+            2430,
+            false,
+            true
+        );
+        return [
+            '1 simple product' => [
+                'products' =>  [$simple1],
+                'expected_payload' => [
+                    $formattedSimple1
+                ]
+            ],
+            '2 simple products' => [
+                'products' =>  [$simple1, $simple2],
+                'expected_payload' => [
+                    $formattedSimple1 ,$formattedSimple2
+                ]
+            ],
+            '1 simple product without category' => [
+                'products' =>  [$simpleWithoutCategory],
+                'expected_payload' => [
+                    $formattedSimpleWithoutCategory
+                ]
+            ],
+            '1 virtual product' => [
+                'products' =>  [$virtualProduct1],
+                'expected_payload' => [
+                    $formattedVirtualProduct1
+                ]
+            ],
+            '1 simple without tax' => [
+                'products' =>  [$simpleWithoutTax],
+                'expected_payload' => [
+                    $formattedSimpleWithoutTax
+                ]
+            ],
+            '1 configurable product with dummy item' => [
+                'products' =>  [$configurableProduct, $dummyConfigurableProduct],
+                'expected_payload' => [
+                    $formattedConfigurableProduct
+                ]
+            ],
+            '1 configurable product with dummy item and 1 simple' => [
+                'products' =>  [
+                    $configurableProduct,
+                    $dummyConfigurableProduct,
+                    $simple1
+                ],
+                'expected_payload' => [
+                    $formattedConfigurableProduct,
+                    $formattedSimple1
+                ]
+            ],
+        ];
+    }
+
+    private function createPaymentDataObject(array $items):PaymentDataObjectInterface
+    {
+        $orderAdapter = $this->createMock(OrderAdapterInterface::class);
+        $orderAdapter->method('getItems')->willReturn($items);
+
+        $paymentDataObject = $this->createMock(PaymentDataObjectInterface::class);
+        $paymentDataObject->method('getOrder')->willReturn($orderAdapter);
+        return $paymentDataObject;
+    }
+
+    private function itemFactory(
+        string $pid,
+        string $sku,
+        string $name,
+        float $qty,
+        float $price,
+        float $rowPrice,
+        bool $isVirtual,
+        float $taxAmount,
+        array $categories = ['3','4'],
+        bool $dummy = false,
+        array $productOptions= []
+    ):Item {
+        $item = $this->createMock(Item::class);
+        $item->method('getProductId')->willReturn($pid);
+        $item->method('getSku')->willReturn($sku);
+        $item->method('getName')->willReturn($name);
+        $item->method('getProductOptions')->willReturn($productOptions);
+        $item->method('getQtyOrdered')->willReturn($qty);
+        $item->method('getPriceInclTax')->willReturn($price);
+        $item->method('getBaseRowTotalInclTax')->willReturn($rowPrice);
+        $item->method('getIsVirtual')->willReturn($isVirtual);
+        $item->method('getTaxAmount')->willReturn($taxAmount);
+        $item->method('isDummy')->willReturn($dummy);
+        return $item;
+    }
+    private function productFactory(
+        string $pid,
+        string $sku,
+        string $name,
+        float $qty,
+        float $price,
+        float $rowPrice,
+        bool $isVirtual,
+        float $taxAmount,
+        array $categories = ['3','4'],
+        bool $dummy = false,
+        array $productOptions= []
+    ):Product {
+        $product = $this->createMock(Product::class);
+        $product->method('getEntityId')->willReturn($pid);
+        $product->method('getName')->willReturn($name);
+        $product->method('getCategoryIds')->willReturn($categories);
+        $product->method('getProductUrl')->willReturn('https://adobe-commerce-a-2-4-5.local.test/fusion-backpack.html');
+        $product->method('getImage')->willReturn('/w/b/wb04-blue-0.jpg');
+        return $product;
+    }
+
+    private function formattedItemFactory(
+        string $sku,
+        string $name,
+        string $variantName,
+        int $qty,
+        int $price,
+        int $rowPrice,
+        bool $isVirtual,
+        bool $taxAmount,
+        array $categories =  ['Gear','Bags']
+    ):array {
+        return [
+            'sku' => $sku,
+            'vendor' => '',
+            'title' => $name,
+            'variant_title' => $variantName,
+            'quantity' => $qty,
+            'unit_price' => $price,
+            'line_price' => $rowPrice,
+            'is_gift' => false,
+            'categories' => $categories,
+            'url' => 'https://adobe-commerce-a-2-4-5.local.test/fusion-backpack.html',
+            'picture_url' => self::MEDIA_BASE_URL . 'catalog/product' . '/w/b/wb04-blue-0.jpg',
+            'requires_shipping' => !$isVirtual,
+            'taxes_included' => $taxAmount
+        ];
+    }
 }

--- a/composer.json
+++ b/composer.json
@@ -6,7 +6,7 @@
         "alma/alma-php-client": ">=1.8.0"
     },
     "type": "magento2-module",
-    "version": "3.3.0",
+    "version": "3.4.0",
     "license": [
         "MIT"
     ],

--- a/etc/di.xml
+++ b/etc/di.xml
@@ -106,6 +106,7 @@
                 <item name="payment" xsi:type="string">Alma\MonthlyPayments\Gateway\Request\PaymentDataBuilder</item>
                 <item name="customer" xsi:type="string">Alma\MonthlyPayments\Gateway\Request\CustomerDataBuilder</item>
                 <item name="order" xsi:type="string">Alma\MonthlyPayments\Gateway\Request\OrderDataBuilder</item>
+                <item name="websiteCustomerDetails" xsi:type="string">Alma\MonthlyPayments\Gateway\Request\WebsiteCustomerDetailsDataBuilder</item>
             </argument>
         </arguments>
     </virtualType>

--- a/etc/module.xml
+++ b/etc/module.xml
@@ -27,7 +27,7 @@
 
 <config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
         xsi:noNamespaceSchemaLocation="urn:magento:framework:Module/etc/module.xsd">
-    <module name="Alma_MonthlyPayments" setup_version="3.3.0">
+    <module name="Alma_MonthlyPayments" setup_version="3.4.0">
         <sequence>
             <module name="Magento_Sales"/>
             <module name="Magento_Payment"/>


### PR DESCRIPTION
### Reason for change

<!-- Describe here the reason for change, and provide a link to the corresponding ClickUp task or Sentry issue. -->

Add 10 customer purchase in payment payload.
Remove first instalment check for SEPA payment


[Linear task](https://linear.app/almapay/issue/MPP-69/magento-retrieve-data-on-10-past-purchases)

### Code changes

Refactor basket items for last purchase 
Remove test condition in payment validation ( firstinstalment === 'paid')

<!-- Describe here the code changes at a high level. Anything that can help reviewers review your PR. -->

Create a new customer and make multiple order.
You must add log in : Alma/MonthlyPayments/Gateway/Request/WebsiteCustomerDetailsDataBuilder.php 
_As a reviewer, you are encouraged to test the PR locally._

<!-- Describe here how to test your changes, if applicable. Insert UI screenshots when relevant -->

### Checklist for authors and reviewers

<!-- Move to the next section the non applicable items -->

- [x] The title of the PR uses business wording, not technical jargon, for the changelog readers to understand it
- [x] The PR implements the changes asked in the referenced task / issue
- [x] The automated tests are compliant with the [testing strategy](https://www.notion.so/almapay/Backend-testing-strategy-06c642cec1bf47b9b8feca3a91ea8d4a)
- [x] The tests are relevant, and cover the corner/error cases, not only the happy path
- [x] You understand the impact of this PR on existing code/features
- [x] The changes include adequate logging and Datadog traces

### Non applicable

<!-- Move here non applicable items of the checklist, if any -->
- [Documentation is updated (API, developer documentation, ADR, Notion...)
