### PR TITLE
fix: change selectPaymentMethod name and call default method

### DIFF
--- a/view/frontend/web/js/view/payment/method-renderer/alma_monthly_payments.js
+++ b/view/frontend/web/js/view/payment/method-renderer/alma_monthly_payments.js
@@ -215,12 +215,13 @@ define(
                     }
                 );
             },
-            selectPaymentMethod : function() {
+            selectAlmaPaymentMethod : function() {
                 self.unMountInPage();
                 const currentPaymentMethod = self.checkedPaymentMethod();
                 if( self.lastSelectedPlan()[currentPaymentMethod].inPageAllowed) {
                     self.selectInstallments(self.lastSelectedPlan()[currentPaymentMethod]);
                 }
+                self.selectPaymentMethod();
                 return true;
             },
             selectInstallments : function(plan){

--- a/view/frontend/web/template/payment/deferred.html
+++ b/view/frontend/web/template/payment/deferred.html
@@ -29,7 +29,7 @@
         <input type="radio"
                name="payment[method]"
                class="radio"
-               data-bind="attr: {'id':  deferredPaymentCode}, value: deferredPaymentCode, checked: checkedPaymentMethod, click: selectPaymentMethod, visible: isRadioButtonVisible()"/>
+               data-bind="attr: {'id':  deferredPaymentCode}, value: deferredPaymentCode, checked: checkedPaymentMethod, click: selectAlmaPaymentMethod, visible: isRadioButtonVisible()"/>
         <label class="label" data-bind="attr: {'for':  deferredPaymentCode}">
             <span data-bind="text: deferredPaymentMethod().title"></span>
         </label>

--- a/view/frontend/web/template/payment/installments.html
+++ b/view/frontend/web/template/payment/installments.html
@@ -29,7 +29,7 @@
         <input type="radio"
                name="payment[method]"
                class="radio"
-               data-bind="attr: {'id':  installmentsPaymentCode}, value: installmentsPaymentCode, checked: checkedPaymentMethod, click: selectPaymentMethod, visible: isRadioButtonVisible()"/>
+               data-bind="attr: {'id':  installmentsPaymentCode}, value: installmentsPaymentCode, checked: checkedPaymentMethod, click: selectAlmaPaymentMethod, visible: isRadioButtonVisible()"/>
         <label class="label" data-bind="attr: {'for':  installmentsPaymentCode}">
             <span data-bind="text: installmentsPaymentMethod().title"></span>
         </label>

--- a/view/frontend/web/template/payment/merged.html
+++ b/view/frontend/web/template/payment/merged.html
@@ -29,7 +29,7 @@
         <input type="radio"
                name="payment[method]"
                class="radio"
-               data-bind="attr: {'id':  mergedPaymentCode}, value: mergedPaymentCode, checked: checkedPaymentMethod, click: selectPaymentMethod, visible: isRadioButtonVisible()"/>
+               data-bind="attr: {'id':  mergedPaymentCode}, value: mergedPaymentCode, checked: checkedPaymentMethod, click: selectAlmaPaymentMethod, visible: isRadioButtonVisible()"/>
         <label class="label" data-bind="attr: {'for':  mergedPaymentCode}">
             <span data-bind="text: mergedPaymentMethod().title"></span>
         </label>

--- a/view/frontend/web/template/payment/paynow.html
+++ b/view/frontend/web/template/payment/paynow.html
@@ -29,7 +29,7 @@
         <input type="radio"
                name="payment[method]"
                class="radio"
-               data-bind="attr: {'id':  paynowPaymentCode}, value: paynowPaymentCode, checked: checkedPaymentMethod, click: selectPaymentMethod, visible: isRadioButtonVisible()"/>
+               data-bind="attr: {'id':  paynowPaymentCode}, value: paynowPaymentCode, checked: checkedPaymentMethod, click: selectAlmaPaymentMethod, visible: isRadioButtonVisible()"/>
         <label class="label" data-bind="attr: {'for':  paynowPaymentCode}">
             <span data-bind="text: paynowPaymentMethod().title"></span>
         </label>

--- a/view/frontend/web/template/payment/spread.html
+++ b/view/frontend/web/template/payment/spread.html
@@ -29,7 +29,7 @@
         <input type="radio"
                name="payment[method]"
                class="radio"
-               data-bind="attr: {'id':  spreadPaymentCode}, value: spreadPaymentCode, checked: checkedPaymentMethod, click: selectPaymentMethod, visible: isRadioButtonVisible()"/>
+               data-bind="attr: {'id':  spreadPaymentCode}, value: spreadPaymentCode, checked: checkedPaymentMethod, click: selectAlmaPaymentMethod, visible: isRadioButtonVisible()"/>
         <label class="label" data-bind="attr: {'for':  spreadPaymentCode}">
             <span data-bind="text: spreadPaymentMethod().title"></span>
         </label>


### PR DESCRIPTION
### Reason for change
Bug on checkout 

<!-- Describe here the reason for change, and provide a link to the corresponding ClickUp task or Sentry issue. -->

[Linear task](https://linear.app/almapay/issue/MPP-620/)

### Code changes

<!-- Describe here the code changes at a high level. Anything that can help reviewers review your PR. -->

### How to test

Select another payment method in first  and after select Alma.
Alma payment method doesn't work fine - no call to set-payment-method in network and no open description.

_As a reviewer, you are encouraged to test the PR locally._

<!-- Describe here how to test your changes, if applicable. Insert UI screenshots when relevant -->

### Checklist for authors and reviewers

<!-- Move to the next section the non applicable items -->

- [ ] The title of the PR uses business wording, not technical jargon, for the changelog readers to understand it
- [ ] The PR implements the changes asked in the referenced task / issue
- [ ] The automated tests are compliant with the [testing strategy](https://www.notion.so/almapay/Backend-testing-strategy-06c642cec1bf47b9b8feca3a91ea8d4a)
- [ ] The tests are relevant, and cover the corner/error cases, not only the happy path
- [ ] You understand the impact of this PR on existing code/features
- [ ] The changes include adequate logging and Datadog traces
- [ ] Documentation is updated (API, developer documentation, ADR, Notion...)

### Non applicable

<!-- Move here non applicable items of the checklist, if any -->
