### PR TITLE
Feature/ecom 1235 adobe commerce get update through webhook

### DIFF
--- a/Helpers/InsuranceHelper.php
+++ b/Helpers/InsuranceHelper.php
@@ -41,7 +41,7 @@ class InsuranceHelper extends AbstractHelper
     const CUSTOMER_SESSION_ID_PARAM_KEY = 'customer_session_id';
     const CUSTOMER_CART_ID_PARAM_KEY = 'cart_id';
     const IS_ALLOWED_INSURANCE_PATH = 'insurance_allowed';
-    const CALLBACK_URI = '/rest/V1/alma/insurance/update?sid=<subscription_id>&trace=<trace>';
+    const CALLBACK_URI = '/rest/V1/alma/insurance/update?subscription_id=<subscription_id>&trace=<trace>';
 
     /**
      * @var ProductRepository

--- a/Model/Api/Insurance/InsuranceUpdate.php
+++ b/Model/Api/Insurance/InsuranceUpdate.php
@@ -2,8 +2,14 @@
 
 namespace Alma\MonthlyPayments\Model\Api\Insurance;
 
+use Alma\API\Exceptions\AlmaException;
 use Alma\MonthlyPayments\Api\Insurance\InsuranceUpdateInterface;
+use Alma\MonthlyPayments\Helpers\AlmaClient;
 use Alma\MonthlyPayments\Helpers\Logger;
+use Alma\MonthlyPayments\Model\Insurance\ResourceModel\Subscription;
+use Alma\MonthlyPayments\Model\Insurance\ResourceModel\Subscription\CollectionFactory;
+use Magento\Framework\Exception\AlreadyExistsException;
+use Magento\Framework\Webapi\Exception;
 use Magento\Framework\Webapi\Rest\Request;
 
 class InsuranceUpdate implements InsuranceUpdateInterface
@@ -16,21 +22,114 @@ class InsuranceUpdate implements InsuranceUpdateInterface
      * @var Request
      */
     private $request;
+    private $almaClient;
+    private CollectionFactory $subscriptionCollection;
+    private Subscription $subscription;
 
+    /**
+     * @param Request $request
+     * @param Logger $logger
+     */
     public function __construct(
-        Request $request,
-        Logger $logger
+        Request           $request,
+        Logger            $logger,
+        AlmaClient        $almaClient,
+        CollectionFactory $subscriptionCollection,
+        Subscription      $subscription
     ) {
-        $this->logger = $logger;
         $this->request = $request;
+        $this->logger = $logger;
+        $this->almaClient = $almaClient;
+        $this->subscriptionCollection = $subscriptionCollection;
+        $this->subscription = $subscription;
     }
 
     /**
      * @return string
+     * @throws Exception
      */
-    public function update(): string
+    public function update():void
     {
-        $postData = $this->request->getBodyParams();
-        return $postData['subscription_id'];
+        $params = $this->request->getParams();
+        $this->checkQeuryParams($params);
+
+        $subscriptionId = $params['subscription_id'];
+        $subscriptions = $this->getSubscription($subscriptionId);
+        $this->checkSubscriptionResponseNotEmpty($subscriptions['subscriptions']);
+
+        $subscription = $subscriptions['subscriptions'][0];
+        $dbSubscription = $this->getDbSubscription($subscriptionId);
+
+        $dbSubscription->setSubscriptionState($subscription['state']);
+        $dbSubscription->setSubscriptionBrokerId($subscription['broker_subscription_id']);
+        try {
+            $this->subscription->save($dbSubscription);
+        } catch (AlreadyExistsException | \Exception $e) {
+            throw new Exception(__('Impossible to save subscription data'), 0, 500);
+        }
+    }
+
+    /**
+     * @param $subscriptions1
+     * @return void
+     * @throws Exception
+     */
+    private function checkSubscriptionResponseNotEmpty($subscriptions1): void
+    {
+        if (!count($subscriptions1)) {
+            throw new Exception(__('Impossible to get subscription_id'), 0, 400);
+        }
+    }
+
+    /**
+     * @param array $params
+     * @throws Exception
+     */
+    private function checkQeuryParams(array $params): void
+    {
+        if (!isset($params['subscription_id'])) {
+            throw new Exception(__('Invalid subscription_id'), 0, 404);
+        }
+    }
+
+    /**
+     * @param $collection
+     * @return void
+     * @throws Exception
+     */
+    private function checkSubscriptionExistInDb($collection): void
+    {
+        if (!$collection->getFirstItem()->getId()) {
+            throw new Exception(__('Subscription not found'), 0, 404);
+        }
+    }
+
+    /**
+     * @param string $subscriptionId
+     * @return array
+     * @throws Exception
+     */
+    private function getSubscription(string $subscriptionId): array
+    {
+        try {
+            $subscriptions = $this->almaClient->getDefaultClient()->insurance->getSubscription(['id' => $subscriptionId]);
+        } catch (AlmaException $e) {
+            $this->logger->error("Error getting subscription:", [$e->getMessage()]);
+            throw new Exception(__('Impossible to get subscription_id'), 0, 404, );
+        }
+        return $subscriptions;
+    }
+
+    /**
+     * @param mixed $subscriptionId
+     * @return \Alma\MonthlyPayments\Model\Insurance\Subscription
+     * @throws Exception
+     */
+    public function getDbSubscription(mixed $subscriptionId)
+    {
+        $collection = $this->subscriptionCollection->create();
+        $collection->addFieldToFilter('subscription_id', $subscriptionId);
+        $this->checkSubscriptionExistInDb($collection);
+        return $collection->getFirstItem();
     }
 }

--- a/Test/Unit/Helpers/InsuranceHelperTest.php
+++ b/Test/Unit/Helpers/InsuranceHelperTest.php
@@ -106,7 +106,7 @@ class InsuranceHelperTest extends TestCase
         $this->dbSubscriptionFactory->method('create')->willReturn($subscriptionMock);
         $this->storeManagerInterface = $this->createMock(StoreManager::class);
         $store = $this->createMock(Store::class);
-        $store->method('getBaseUrl')->willReturn('http://my-website.com');
+        $store->method('getBaseUrl')->willReturn('https://my-website.com');
         $this->storeManagerInterface->method('getStore')->willReturn($store);
 
         $this->insuranceHelper = $this->createNewInsuranceHelper();
@@ -657,7 +657,7 @@ class InsuranceHelperTest extends TestCase
                 'linked_product_price' => 5900,
                 'subscription_state' => 'started',
                 'mode' => 'test',
-                'callback_url' => 'http://my-website.com/rest/V1/alma/insurance/update?subscription_id=<subscription_id>&trace=<trace>',
+                'callback_url' => 'https://my-website.com/rest/V1/alma/insurance/update?subscription_id=<subscription_id>&trace=<trace>',
             ],
             [
                 'order_id' => 2,
@@ -672,7 +672,7 @@ class InsuranceHelperTest extends TestCase
                 'linked_product_price' => 5600,
                 'subscription_state' => 'started',
                 'mode' => 'test',
-                'callback_url' => 'http://my-website.com/rest/V1/alma/insurance/update?subscription_id=<subscription_id>&trace=<trace>',
+                'callback_url' => 'https://my-website.com/rest/V1/alma/insurance/update?subscription_id=<subscription_id>&trace=<trace>',
             ],
         ];
         $arraySubscriptionResult = $this->insuranceHelper->createDbSubscriptionArrayFromItemsAndApiResult(
@@ -694,7 +694,7 @@ class InsuranceHelperTest extends TestCase
             $sku,
             12012,
             $subscriber,
-            'http://my-website.com/rest/V1/alma/insurance/update'
+            'https://my-website.com/rest/V1/alma/insurance/update'
         );
     }
 

--- a/Test/Unit/Helpers/InsuranceHelperTest.php
+++ b/Test/Unit/Helpers/InsuranceHelperTest.php
@@ -657,7 +657,7 @@ class InsuranceHelperTest extends TestCase
                 'linked_product_price' => 5900,
                 'subscription_state' => 'started',
                 'mode' => 'test',
-                'callback_url' => 'http://my-website.com/rest/V1/alma/insurance/update?sid=<subscription_id>&trace=<trace>',
+                'callback_url' => 'http://my-website.com/rest/V1/alma/insurance/update?subscription_id=<subscription_id>&trace=<trace>',
             ],
             [
                 'order_id' => 2,
@@ -672,7 +672,7 @@ class InsuranceHelperTest extends TestCase
                 'linked_product_price' => 5600,
                 'subscription_state' => 'started',
                 'mode' => 'test',
-                'callback_url' => 'http://my-website.com/rest/V1/alma/insurance/update?sid=<subscription_id>&trace=<trace>',
+                'callback_url' => 'http://my-website.com/rest/V1/alma/insurance/update?subscription_id=<subscription_id>&trace=<trace>',
             ],
         ];
         $arraySubscriptionResult = $this->insuranceHelper->createDbSubscriptionArrayFromItemsAndApiResult(

--- a/Test/Unit/Model/Api/Insurance/InsuranceUpdateTest.php
+++ b/Test/Unit/Model/Api/Insurance/InsuranceUpdateTest.php
@@ -1,0 +1,189 @@
+<?php
+
+namespace Alma\MonthlyPayments\Test\Unit\Model\Api\Insurance;
+
+use Alma\API\Client;
+use Alma\API\Endpoints\Insurance;
+use Alma\MonthlyPayments\Helpers\AlmaClient;
+use Alma\MonthlyPayments\Helpers\Logger;
+use Alma\MonthlyPayments\Model\Api\Insurance\InsuranceUpdate;
+use Alma\MonthlyPayments\Model\Insurance\ResourceModel\Subscription;
+use Alma\MonthlyPayments\Model\Insurance\ResourceModel\Subscription\CollectionFactory;
+use Magento\Framework\Webapi\Rest\Request;
+use PHPUnit\Framework\TestCase;
+
+class InsuranceUpdateTest extends TestCase
+{
+
+    /**
+     * @var Logger
+     */
+    private $logger;
+    /**
+     * @var Request
+     */
+    private $request;
+
+    private $almaClient;
+
+    private $subscriptionRessourceModel;
+    private $subscriptionCollection;
+
+    /**
+     * @return void
+     */
+    public function setUp(): void
+    {
+        $this->request = $this->createMock(\Magento\Framework\Webapi\Rest\Request::class);
+        $this->logger = $this->createMock(\Alma\MonthlyPayments\Helpers\Logger::class);
+        $this->almaClient = $this->createMock(AlmaClient::class);
+        $this->subscriptionCollection = $this->createMock(CollectionFactory::class);
+        $this->subscriptionRessourceModel = $this->createMock(Subscription::class);
+    }
+
+    /**
+     * @return array[]
+     */
+    public function getConstructorDependencies(): array
+    {
+        return [
+            $this->request,
+            $this->logger,
+            $this->almaClient,
+            $this->subscriptionCollection,
+            $this->subscriptionRessourceModel
+        ];
+    }
+
+    /**
+     * @return InsuranceUpdate
+     */
+    private function createInstance(): InsuranceUpdate
+    {
+        return new \Alma\MonthlyPayments\Model\Api\Insurance\InsuranceUpdate(
+            ...$this->getConstructorDependencies()
+        );
+    }
+
+    public function testGivenInvalidSubscriptionIdKeyMustReturnError(): void
+    {
+        $this->request->expects($this->once())
+            ->method('getParams')
+            ->willReturn(['sid' => 'invalid_subscription_key']);
+
+        $this->expectException(\Magento\Framework\Webapi\Exception::class);
+        $instance = $this->createInstance();
+        $instance->update();
+    }
+
+    public function testGivenSubscriptionIdReturnApiErrorMustReturnError(): void
+    {
+        $this->request->expects($this->once())
+            ->method('getParams')
+            ->willReturn(['subscription_id' => 'valid_subscription_key']);
+
+        $insuranceEndpoint = $this->createMock(Insurance::class);
+        $insuranceEndpoint->expects($this->once())->method('getSubscription')->willThrowException(new \Alma\API\Exceptions\AlmaException('error'));
+        $almaClient = $this->createMock(Client::class);
+        $almaClient->insurance = $insuranceEndpoint;
+        $this->almaClient->method('getDefaultClient')->willReturn($almaClient);
+        $this->expectException(\Magento\Framework\Webapi\Exception::class);
+        $instance = $this->createInstance();
+        $instance->update();
+    }
+    public function testGivenSubscriptionIdReturnEmptySubscriptionListMustReturnError(): void
+    {
+        $this->request->expects($this->once())
+            ->method('getParams')
+            ->willReturn(['subscription_id' => 'valid_subscription_key']);
+
+        $insuranceEndpoint = $this->createMock(Insurance::class);
+        $insuranceEndpoint->expects($this->once())->method('getSubscription')->willReturn(
+            ['subscriptions' => []]
+        );
+        $almaClient = $this->createMock(Client::class);
+        $almaClient->insurance = $insuranceEndpoint;
+        $this->almaClient->method('getDefaultClient')->willReturn($almaClient);
+        $this->expectException(\Magento\Framework\Webapi\Exception::class);
+        $instance = $this->createInstance();
+        $instance->update();
+    }
+
+    public function testGivenEmptyDbSubscriptionMustThrow():void
+    {
+        $this->request->expects($this->once())
+            ->method('getParams')
+            ->willReturn(['subscription_id' => 'valid_subscription_key']);
+
+        $insuranceEndpoint = $this->createMock(Insurance::class);
+        $insuranceEndpoint->expects($this->once())->method('getSubscription')->with(['id' => 'valid_subscription_key'])->willReturn($this->getSubscriptionResultData());
+        $almaClient = $this->createMock(Client::class);
+        $almaClient->insurance = $insuranceEndpoint;
+        $this->almaClient->method('getDefaultClient')->willReturn($almaClient);
+        $dbSubscriptionMock = $this->createMock(\Alma\MonthlyPayments\Model\Insurance\Subscription::class);
+        $dbSubscriptionMock->method('getId')->willReturn(null);
+        $collectionMock = $this->createMock(Subscription\Collection::class);
+        $collectionMock->method('getFirstItem')->willReturn($dbSubscriptionMock);
+        $collectionMock->method('addFieldToFilter')->willReturn($collectionMock);
+
+        $this->subscriptionCollection->method('create')->willReturn($collectionMock);
+        $this->expectException(\Exception::class);
+        $instance = $this->createInstance();
+        $instance->update();
+    }
+
+    public function testGivenAValidApiReturnMustLoadAndSaveModelFromRepository(): void
+    {
+        $this->request->expects($this->once())
+            ->method('getParams')
+            ->willReturn(['subscription_id' => 'valid_subscription_key']);
+
+        $insuranceEndpoint = $this->createMock(Insurance::class);
+        $apiResult = $this->getSubscriptionResultData();
+        $insuranceEndpoint->expects($this->once())->method('getSubscription')->with(['id' => 'valid_subscription_key'])->willReturn($this->getSubscriptionResultData($apiResult));
+        $almaClient = $this->createMock(Client::class);
+        $almaClient->insurance = $insuranceEndpoint;
+        $this->almaClient->method('getDefaultClient')->willReturn($almaClient);
+        $dbSubscriptionMock = $this->createMock(\Alma\MonthlyPayments\Model\Insurance\Subscription::class);
+        $dbSubscriptionMock->method('getId')->willReturn(1);
+        $dbSubscriptionMock->method('setSubscriptionState')->with($apiResult['subscriptions'][0]['state']);
+        $dbSubscriptionMock->method('setSubscriptionBrokerId')->with($apiResult['subscriptions'][0]['broker_subscription_id']);
+        $this->subscriptionRessourceModel->expects($this->once())->method('save')->with($dbSubscriptionMock);
+        $collectionMock = $this->createMock(Subscription\Collection::class);
+        $collectionMock->method('getFirstItem')->willReturn($dbSubscriptionMock);
+        $collectionMock->method('addFieldToFilter')->willReturn($collectionMock);
+
+        $this->subscriptionCollection->method('create')->willReturn($collectionMock);
+
+        $instance = $this->createInstance();
+        $this->assertNull($instance->update());
+    }
+
+
+    private function getSubscriptionResultData(): array
+    {
+        return [
+            "subscriptions" => [
+                [
+                    "amount" => 1312,
+                    "cms_reference" => "19",
+                    "contract_id" => "insurance_contract_755vkKQUnezKPvzMWc4Qeq",
+                    "id" => "subscription_5FM3wla3WvVjFaOUb06nXt",
+                    "broker_subscription_id" => "xxxx",
+                    "state" => "cancel",
+                    "subscriber" => [
+                        "address_line_1" => "adr1",
+                        "address_line_2" => "adr1",
+                        "city" => "adr1",
+                        "country" => "adr1",
+                        "email" => "mathis.dupuy@almapay.com",
+                        "first_name" => "sub1",
+                        "last_name" => "sub1",
+                        "phone_number" => "+33622484646",
+                        "zip_code" => "adr1"
+                    ]
+                ]
+            ]
+        ];
+    }
+}

--- a/etc/webapi.xml
+++ b/etc/webapi.xml
@@ -45,7 +45,7 @@
             <resource ref="anonymous"/>
         </resources>
     </route>
-    <route url="/V1/alma/insurance/update" method="POST">
+    <route url="/V1/alma/insurance/update" method="GET">
         <service class="Alma\MonthlyPayments\Api\Insurance\InsuranceUpdateInterface" method="update"/>
         <resources>
             <resource ref="anonymous"/>


### PR DESCRIPTION
### Reason for change

<!-- Describe here the reason for change, and provide a link to the corresponding ClickUp task or Sentry issue. -->

Create a a post controller to update db subscription DAta.

[Linear task](https://linear.app/almapay/issue/ECOM-1235/adobe-commerce-get-update-through-webhook)

### Code changes

<!-- Describe here the code changes at a high level. Anything that can help reviewers review your PR. -->

### How to test

_As a reviewer, you are encouraged to test the PR locally._

<!-- Describe here how to test your changes, if applicable. Insert UI screenshots when relevant -->

### Checklist for authors and reviewers

<!-- Move to the next section the non applicable items -->

- [ ] The title of the PR uses business wording, not technical jargon, for the changelog readers to understand it
- [ ] The PR implements the changes asked in the referenced task / issue
- [ ] The automated tests are compliant with the [testing strategy](https://www.notion.so/almapay/Backend-testing-strategy-06c642cec1bf47b9b8feca3a91ea8d4a)
- [ ] The tests are relevant, and cover the corner/error cases, not only the happy path
- [ ] You understand the impact of this PR on existing code/features
- [ ] The changes include adequate logging and Datadog traces
- [ ] Documentation is updated (API, developer documentation, ADR, Notion...)

### Non applicable

<!-- Move here non applicable items of the checklist, if any -->
