### PR TITLE
Feature/ecom 1336 adobe commerce call endpoint with cms reference

### DIFF
--- a/Helpers/InsuranceSendCustomerCartHelper.php
+++ b/Helpers/InsuranceSendCustomerCartHelper.php
@@ -40,7 +40,9 @@ class InsuranceSendCustomerCartHelper extends AbstractHelper
             }
             $sku = $item->getSku();
             if ($sku !== InsuranceHelper::ALMA_INSURANCE_SKU) {
-                $items[] = $sku;
+                for ($i = 0; $i < (int)$item->getQty(); $i++) {
+                    $items[] = $sku;
+                }
             }
         }
         try {

--- a/Helpers/InsuranceSendCustomerCartHelper.php
+++ b/Helpers/InsuranceSendCustomerCartHelper.php
@@ -1,0 +1,46 @@
+<?php
+
+namespace Alma\MonthlyPayments\Helpers;
+
+use Alma\API\RequestError;
+use Alma\MonthlyPayments\Helpers\Exceptions\AlmaClientException;
+use Magento\Framework\App\Helper\AbstractHelper;
+use Magento\Framework\App\Helper\Context;
+use Magento\Sales\Model\ResourceModel\Order\Invoice\Item\Collection;
+
+class InsuranceSendCustomerCartHelper extends AbstractHelper
+{
+    private AlmaClient $almaClient;
+    private Logger $logger;
+
+    public function __construct(
+        Context $context,
+        AlmaClient $almaClient,
+        Logger $logger
+    ) {
+        parent::__construct($context);
+        $this->almaClient = $almaClient;
+        $this->logger = $logger;
+    }
+
+    /**
+     * @param Collection $invoicesItemsCollection
+     * @param int $quoteId
+     * @return void
+     */
+    public function sendCustomerCart(Collection $invoicesItemsCollection, int $orderId)
+    {
+        $items = [];
+        foreach ($invoicesItemsCollection as $item) {
+            $sku = $item->getSku();
+            if ($sku !== InsuranceHelper::ALMA_INSURANCE_SKU) {
+                $items[] = $sku;
+            }
+        }
+        try {
+            $this->almaClient->getDefaultClient()->insurance->sendCustomerCart($items, $orderId);
+        } catch (RequestError | AlmaClientException $e) {
+            $this->logger->error('Error sending customer cart to Alma', ['exception' => $e]);
+        }
+    }
+}

--- a/Helpers/InsuranceSendCustomerCartHelper.php
+++ b/Helpers/InsuranceSendCustomerCartHelper.php
@@ -35,7 +35,7 @@ class InsuranceSendCustomerCartHelper extends AbstractHelper
         $items = [];
         /** @var Item $item */
         foreach ($invoicesItemsCollection as $item) {
-            if ($item->getParentId()) {
+            if ($item->getOrderItem()->getParentItemId()) {
                 continue;
             }
             $sku = $item->getSku();

--- a/Observer/SalesOrderInvoicePayObserver.php
+++ b/Observer/SalesOrderInvoicePayObserver.php
@@ -6,6 +6,7 @@ use Alma\API\Exceptions\AlmaException;
 use Alma\MonthlyPayments\Helpers\AlmaClient;
 use Alma\MonthlyPayments\Helpers\ApiConfigHelper;
 use Alma\MonthlyPayments\Helpers\InsuranceHelper;
+use Alma\MonthlyPayments\Helpers\InsuranceSendCustomerCartHelper;
 use Alma\MonthlyPayments\Helpers\Logger;
 use Alma\MonthlyPayments\Model\Insurance\ResourceModel\Subscription;
 use Magento\Framework\Event\Observer;
@@ -36,19 +37,22 @@ class SalesOrderInvoicePayObserver implements ObserverInterface
      * @var ApiConfigHelper
      */
     private $apiConfigHelper;
+    private InsuranceSendCustomerCartHelper $insuranceSendCustomerCartHelper;
 
     public function __construct(
         Logger          $logger,
         InsuranceHelper $insuranceHelper,
         AlmaClient      $almaClient,
         Subscription    $subscriptionResourceModel,
-        ApiConfigHelper $apiConfigHelper
+        ApiConfigHelper $apiConfigHelper,
+        InsuranceSendCustomerCartHelper $insuranceSendCustomerCartHelper
     ) {
         $this->logger = $logger;
         $this->insuranceHelper = $insuranceHelper;
         $this->almaClient = $almaClient;
         $this->subscriptionResourceModel = $subscriptionResourceModel;
         $this->apiConfigHelper = $apiConfigHelper;
+        $this->insuranceSendCustomerCartHelper = $insuranceSendCustomerCartHelper;
     }
 
     /**
@@ -63,7 +67,7 @@ class SalesOrderInvoicePayObserver implements ObserverInterface
 
         /** @var Collection $invoicedItems */
         $invoicedItems = $invoice->getItems();
-
+        $this->insuranceSendCustomerCartHelper->sendCustomerCart($invoicedItems);
         $subscriptionArray = $this->insuranceHelper->getSubscriptionData($invoicedItems, $subscriber);
 
         // Exit if no subscription in invoice

--- a/Observer/SalesOrderInvoicePayObserver.php
+++ b/Observer/SalesOrderInvoicePayObserver.php
@@ -67,7 +67,8 @@ class SalesOrderInvoicePayObserver implements ObserverInterface
 
         /** @var Collection $invoicedItems */
         $invoicedItems = $invoice->getItems();
-        $this->insuranceSendCustomerCartHelper->sendCustomerCart($invoicedItems);
+        $orderId = $invoice->getOrder()->getQuoteId();
+        $this->insuranceSendCustomerCartHelper->sendCustomerCart($invoicedItems, $orderId);
         $subscriptionArray = $this->insuranceHelper->getSubscriptionData($invoicedItems, $subscriber);
 
         // Exit if no subscription in invoice
@@ -77,7 +78,7 @@ class SalesOrderInvoicePayObserver implements ObserverInterface
         }
 
         try {
-            $return = $this->almaClient->getDefaultClient()->insurance->subscription($subscriptionArray, null, null, $invoice->getOrder()->getQuoteId());
+            $return = $this->almaClient->getDefaultClient()->insurance->subscription($subscriptionArray, null, null, $orderId);
             if (!$return['subscriptions']) {
                 $this->logger->error('Warning No subscription data in Alma return', [$return]);
                 return;

--- a/Observer/SalesOrderInvoicePayObserver.php
+++ b/Observer/SalesOrderInvoicePayObserver.php
@@ -56,18 +56,13 @@ class SalesOrderInvoicePayObserver implements ObserverInterface
      */
     public function execute(Observer $observer)
     {
-        $this->logger->info('In Sales order invoice pay observer', []);
         /** @var Invoice $invoice */
         $invoice = $observer->getEvent()->getData('invoice');
-        $this->logger->info('$invoice', [$invoice]);
         $billingAddress = $invoice->getBillingAddress();
-        $this->logger->info('$billingAddress', [$billingAddress]);
         $subscriber = $this->insuranceHelper->getSubscriberByAddress($billingAddress);
-        $this->logger->info('$subscriber', [$subscriber]);
 
         /** @var Collection $invoicedItems */
         $invoicedItems = $invoice->getItems();
-        $this->logger->info('$invoicedItems', [$invoicedItems]);
 
         $subscriptionArray = $this->insuranceHelper->getSubscriptionData($invoicedItems, $subscriber);
 
@@ -77,10 +72,8 @@ class SalesOrderInvoicePayObserver implements ObserverInterface
             return;
         }
 
-        $this->logger->info('$subscriptionArray', [$subscriptionArray]);
         try {
             $return = $this->almaClient->getDefaultClient()->insurance->subscription($subscriptionArray, null, null, $invoice->getOrder()->getQuoteId());
-            $this->logger->info('$return', [$return]);
             if (!$return['subscriptions']) {
                 $this->logger->error('Warning No subscription data in Alma return', [$return]);
                 return;

--- a/Observer/SalesOrderInvoicePayObserver.php
+++ b/Observer/SalesOrderInvoicePayObserver.php
@@ -67,8 +67,7 @@ class SalesOrderInvoicePayObserver implements ObserverInterface
 
         /** @var Collection $invoicedItems */
         $invoicedItems = $invoice->getItems();
-        $orderId = $invoice->getOrder()->getQuoteId();
-        $this->insuranceSendCustomerCartHelper->sendCustomerCart($invoicedItems, $orderId);
+        $this->insuranceSendCustomerCartHelper->sendCustomerCart($invoicedItems, $invoice->getOrder()->getQuoteId());
         $subscriptionArray = $this->insuranceHelper->getSubscriptionData($invoicedItems, $subscriber);
 
         // Exit if no subscription in invoice
@@ -78,7 +77,7 @@ class SalesOrderInvoicePayObserver implements ObserverInterface
         }
 
         try {
-            $return = $this->almaClient->getDefaultClient()->insurance->subscription($subscriptionArray, null, null, $orderId);
+            $return = $this->almaClient->getDefaultClient()->insurance->subscription($subscriptionArray, null, null, $invoice->getOrder()->getQuoteId());
             if (!$return['subscriptions']) {
                 $this->logger->error('Warning No subscription data in Alma return', [$return]);
                 return;

--- a/Test/Unit/Helpers/InsuranceSendCustomerCartHelperTest.php
+++ b/Test/Unit/Helpers/InsuranceSendCustomerCartHelperTest.php
@@ -1,0 +1,90 @@
+<?php
+
+namespace Alma\MonthlyPayments\Test\Unit\Helpers;
+
+use Alma\API\Client;
+use Alma\API\Endpoints\Insurance;
+use Alma\MonthlyPayments\Helpers\AlmaClient;
+use Alma\MonthlyPayments\Helpers\Exceptions\AlmaClientException;
+use Alma\MonthlyPayments\Helpers\InsuranceHelper;
+use Alma\MonthlyPayments\Helpers\InsuranceSendCustomerCartHelper;
+use Alma\MonthlyPayments\Helpers\Logger;
+use Magento\Framework\App\Helper\Context;
+use Magento\Sales\Model\ResourceModel\Order\Invoice\Item\Collection;
+use PHPUnit\Framework\TestCase;
+
+class InsuranceSendCustomerCartHelperTest extends TestCase
+{
+    /**
+     * @var AlmaClient
+     */
+    private $almaClient;
+    /**
+     * @var Context
+     */
+    private $context;
+    private $orderId;
+    /**
+     * @var Logger
+     */
+    private $logger;
+    protected function setUp(): void
+    {
+        $this->almaClient = $this->createMock(AlmaClient::class);
+        $this->context = $this->createMock(Context::class);
+        $this->logger = $this->createMock(Logger::class);
+        $this->orderId = 42;
+    }
+    private function getConstructorDependencies(): array
+    {
+        return [
+            $this->context,
+            $this->almaClient,
+            $this->logger
+        ];
+    }
+
+    private function newInsuranceSendCustomerCartHelper(): InsuranceSendCustomerCartHelper
+    {
+        return new InsuranceSendCustomerCartHelper(...$this->getConstructorDependencies());
+    }
+
+    public function testSendCustomerCartMustReturnNullNeverThrowException()
+    {
+        $itemsCollection = $this->collectionFactory();
+        $newInsuranceSendCustomerCartHelper = $this->newInsuranceSendCustomerCartHelper();
+        $insuranceEndpoint = $this->createMock(Insurance::class);
+        $insuranceEndpoint->method('sendCustomerCart')->willThrowException(new AlmaClientException('Error sending customer cart to Alma'));
+        $client = $this->createMock(Client::class);
+        $client->insurance = $insuranceEndpoint;
+        $this->almaClient->expects($this->once())->method('getDefaultClient')->willReturn($client);
+        $this->logger->expects($this->once())->method('error');
+        $this->assertNull($newInsuranceSendCustomerCartHelper->sendCustomerCart($itemsCollection, $this->orderId));
+    }
+
+    public function testGivenItemsCollectionWhenSendCustomerCartThenCallAlmaClient()
+    {
+        $itemsCollection = $this->collectionFactory();
+        $insuranceEndpoint = $this->createMock(Insurance::class);
+        $insuranceEndpoint->expects($this->once())->method('sendCustomerCart')->with(['mb-024', 'mb-025']);
+        $client = $this->createMock(Client::class);
+        $client->insurance = $insuranceEndpoint;
+        $this->almaClient->expects($this->once())->method('getDefaultClient')->willReturn($client);
+        $newInsuranceSendCustomerCartHelper = $this->newInsuranceSendCustomerCartHelper();
+        $newInsuranceSendCustomerCartHelper->sendCustomerCart($itemsCollection, $this->orderId);
+    }
+
+    private function collectionFactory(): Collection
+    {
+        $item1 = $this->createMock(\Magento\Sales\Model\Order\Invoice\Item::class);
+        $item1->expects($this->once())->method('getSku')->willReturn('mb-024');
+        $item2 = $this->createMock(\Magento\Sales\Model\Order\Invoice\Item::class);
+        $item2->expects($this->once())->method('getSku')->willReturn('mb-025');
+        $item3 = $this->createMock(\Magento\Sales\Model\Order\Invoice\Item::class);
+        $item3->expects($this->once())->method('getSku')->willReturn(InsuranceHelper::ALMA_INSURANCE_SKU);
+        $iterator = new \ArrayIterator([$item1, $item2, $item3]);
+        $itemsCollection = $this->createMock(Collection::class);
+        $itemsCollection->expects($this->once())->method('getIterator')->willReturn($iterator);
+        return $itemsCollection;
+    }
+}

--- a/Test/Unit/Helpers/InsuranceSendCustomerCartHelperTest.php
+++ b/Test/Unit/Helpers/InsuranceSendCustomerCartHelperTest.php
@@ -91,24 +91,33 @@ class InsuranceSendCustomerCartHelperTest extends TestCase
         $items = [];
         $item1 = $this->createMock(\Magento\Sales\Model\Order\Invoice\Item::class);
         $item1->expects($this->once())->method('getSku')->willReturn('mb-024');
-        $item1->expects($this->once())->method('getParentId')->willReturn(null);
+        $orderItem1 = $this->createMock(\Magento\Sales\Model\Order\Item::class);
+        $orderItem1->expects($this->once())->method('getParentItemId')->willReturn(null);
+        $item1->expects($this->once())->method('getOrderItem')->willReturn($orderItem1);
         $items[] = $item1;
 
         $item2 = $this->createMock(\Magento\Sales\Model\Order\Invoice\Item::class);
         $item2->expects($this->once())->method('getSku')->willReturn(InsuranceHelper::ALMA_INSURANCE_SKU);
-        $item2->expects($this->once())->method('getParentId')->willReturn(null);
+        $orderItem2 = $this->createMock(\Magento\Sales\Model\Order\Item::class);
+        $orderItem2->expects($this->once())->method('getParentItemId')->willReturn(null);
+        $item2->expects($this->once())->method('getOrderItem')->willReturn($orderItem2);
+
         $items[] = $item2;
 
         if ($withConfigurable) {
             $item3 = $this->createMock(\Magento\Sales\Model\Order\Invoice\Item::class);
             $item3->method('getSku')->willReturn('mb-024');
-            $item3->expects($this->once())->method('getParentId')->willReturn(23);
+            $orderItem3 = $this->createMock(\Magento\Sales\Model\Order\Item::class);
+            $orderItem3->expects($this->once())->method('getParentItemId')->willReturn(30);
+            $item3->expects($this->once())->method('getOrderItem')->willReturn($orderItem3);
             $items[] = $item3;
         }
 
         $item4 = $this->createMock(\Magento\Sales\Model\Order\Invoice\Item::class);
         $item4->expects($this->once())->method('getSku')->willReturn('mb-025');
-        $item4->expects($this->once())->method('getParentId')->willReturn(null);
+        $orderItem4 = $this->createMock(\Magento\Sales\Model\Order\Item::class);
+        $orderItem4->expects($this->once())->method('getParentItemId')->willReturn(null);
+        $item4->expects($this->once())->method('getOrderItem')->willReturn($orderItem4);
         $items[] = $item4;
 
         $iterator = new \ArrayIterator($items);

--- a/Test/Unit/Helpers/InsuranceSendCustomerCartHelperTest.php
+++ b/Test/Unit/Helpers/InsuranceSendCustomerCartHelperTest.php
@@ -10,6 +10,7 @@ use Alma\MonthlyPayments\Helpers\InsuranceHelper;
 use Alma\MonthlyPayments\Helpers\InsuranceSendCustomerCartHelper;
 use Alma\MonthlyPayments\Helpers\Logger;
 use Magento\Framework\App\Helper\Context;
+use Magento\Sales\Model\Order\Invoice\Item;
 use Magento\Sales\Model\ResourceModel\Order\Invoice\Item\Collection;
 use PHPUnit\Framework\TestCase;
 
@@ -88,42 +89,28 @@ class InsuranceSendCustomerCartHelperTest extends TestCase
 
     private function collectionFactory($withConfigurable = false): Collection
     {
-        $items = [];
-        $item1 = $this->createMock(\Magento\Sales\Model\Order\Invoice\Item::class);
-        $item1->expects($this->once())->method('getSku')->willReturn('mb-024');
-        $orderItem1 = $this->createMock(\Magento\Sales\Model\Order\Item::class);
-        $orderItem1->expects($this->once())->method('getParentItemId')->willReturn(null);
-        $item1->expects($this->once())->method('getOrderItem')->willReturn($orderItem1);
-        $items[] = $item1;
-
-        $item2 = $this->createMock(\Magento\Sales\Model\Order\Invoice\Item::class);
-        $item2->expects($this->once())->method('getSku')->willReturn(InsuranceHelper::ALMA_INSURANCE_SKU);
-        $orderItem2 = $this->createMock(\Magento\Sales\Model\Order\Item::class);
-        $orderItem2->expects($this->once())->method('getParentItemId')->willReturn(null);
-        $item2->expects($this->once())->method('getOrderItem')->willReturn($orderItem2);
-
-        $items[] = $item2;
-
+        $items=[
+            $this->invoiceItemFactory('mb-024'),
+            $this->invoiceItemFactory(InsuranceHelper::ALMA_INSURANCE_SKU),
+            $this->invoiceItemFactory('mb-025')
+        ];
         if ($withConfigurable) {
-            $item3 = $this->createMock(\Magento\Sales\Model\Order\Invoice\Item::class);
-            $item3->method('getSku')->willReturn('mb-024');
-            $orderItem3 = $this->createMock(\Magento\Sales\Model\Order\Item::class);
-            $orderItem3->expects($this->once())->method('getParentItemId')->willReturn(30);
-            $item3->expects($this->once())->method('getOrderItem')->willReturn($orderItem3);
-            $items[] = $item3;
+            $items[] = $this->invoiceItemFactory('mb-024', 30);
         }
-
-        $item4 = $this->createMock(\Magento\Sales\Model\Order\Invoice\Item::class);
-        $item4->expects($this->once())->method('getSku')->willReturn('mb-025');
-        $orderItem4 = $this->createMock(\Magento\Sales\Model\Order\Item::class);
-        $orderItem4->expects($this->once())->method('getParentItemId')->willReturn(null);
-        $item4->expects($this->once())->method('getOrderItem')->willReturn($orderItem4);
-        $items[] = $item4;
-
         $iterator = new \ArrayIterator($items);
 
         $itemsCollection = $this->createMock(Collection::class);
         $itemsCollection->expects($this->once())->method('getIterator')->willReturn($iterator);
         return $itemsCollection;
+    }
+
+    private function invoiceItemFactory(string $sku, ?int $parentItemId = null):Item
+    {
+        $item = $this->createMock(\Magento\Sales\Model\Order\Invoice\Item::class);
+        $item->method('getSku')->willReturn($sku);
+        $orderItem = $this->createMock(\Magento\Sales\Model\Order\Item::class);
+        $orderItem->expects($this->once())->method('getParentItemId')->willReturn($parentItemId);
+        $item->expects($this->once())->method('getOrderItem')->willReturn($orderItem);
+        return $item;
     }
 }

--- a/Test/Unit/Helpers/InsuranceSendCustomerCartHelperTest.php
+++ b/Test/Unit/Helpers/InsuranceSendCustomerCartHelperTest.php
@@ -67,7 +67,7 @@ class InsuranceSendCustomerCartHelperTest extends TestCase
     {
         $itemsCollection = $this->collectionFactory();
         $insuranceEndpoint = $this->createMock(Insurance::class);
-        $insuranceEndpoint->expects($this->once())->method('sendCustomerCart')->with(['mb-024', 'mb-025']);
+        $insuranceEndpoint->expects($this->once())->method('sendCustomerCart')->with(['mb-024', 'mb-025', 'mb-025']);
         $client = $this->createMock(Client::class);
         $client->insurance = $insuranceEndpoint;
         $this->almaClient->expects($this->once())->method('getDefaultClient')->willReturn($client);
@@ -79,7 +79,7 @@ class InsuranceSendCustomerCartHelperTest extends TestCase
     {
         $itemsCollection = $this->collectionFactory(true);
         $insuranceEndpoint = $this->createMock(Insurance::class);
-        $insuranceEndpoint->expects($this->once())->method('sendCustomerCart')->with(['mb-024', 'mb-025']);
+        $insuranceEndpoint->expects($this->once())->method('sendCustomerCart')->with(['mb-024', 'mb-025', 'mb-025']);
         $client = $this->createMock(Client::class);
         $client->insurance = $insuranceEndpoint;
         $this->almaClient->expects($this->once())->method('getDefaultClient')->willReturn($client);
@@ -92,10 +92,10 @@ class InsuranceSendCustomerCartHelperTest extends TestCase
         $items=[
             $this->invoiceItemFactory('mb-024'),
             $this->invoiceItemFactory(InsuranceHelper::ALMA_INSURANCE_SKU),
-            $this->invoiceItemFactory('mb-025')
+            $this->invoiceItemFactory('mb-025', 2.0000)
         ];
         if ($withConfigurable) {
-            $items[] = $this->invoiceItemFactory('mb-024', 30);
+            $items[] = $this->invoiceItemFactory('mb-024', 1.0000,30);
         }
         $iterator = new \ArrayIterator($items);
 
@@ -104,10 +104,11 @@ class InsuranceSendCustomerCartHelperTest extends TestCase
         return $itemsCollection;
     }
 
-    private function invoiceItemFactory(string $sku, ?int $parentItemId = null):Item
+    private function invoiceItemFactory(string $sku, float $qty = 1.000, ?int $parentItemId = null):Item
     {
         $item = $this->createMock(\Magento\Sales\Model\Order\Invoice\Item::class);
         $item->method('getSku')->willReturn($sku);
+        $item->method('getQty')->willReturn($qty);
         $orderItem = $this->createMock(\Magento\Sales\Model\Order\Item::class);
         $orderItem->expects($this->once())->method('getParentItemId')->willReturn($parentItemId);
         $item->expects($this->once())->method('getOrderItem')->willReturn($orderItem);

--- a/Test/Unit/Observer/SalesOrderInvoicePayObserverTest.php
+++ b/Test/Unit/Observer/SalesOrderInvoicePayObserverTest.php
@@ -8,6 +8,7 @@ use Alma\API\Entities\Insurance\Subscriber;
 use Alma\MonthlyPayments\Helpers\AlmaClient;
 use Alma\MonthlyPayments\Helpers\ApiConfigHelper;
 use Alma\MonthlyPayments\Helpers\InsuranceHelper;
+use Alma\MonthlyPayments\Helpers\InsuranceSendCustomerCartHelper;
 use Alma\MonthlyPayments\Helpers\Logger;
 use Alma\MonthlyPayments\Model\Insurance\Subscription;
 use Alma\MonthlyPayments\Observer\SalesOrderInvoicePayObserver;
@@ -42,6 +43,10 @@ class SalesOrderInvoicePayObserverTest extends TestCase
      * @var \Alma\MonthlyPayments\Model\Insurance\ResourceModel\Subscription
      */
     private $subscriptionResourceModel;
+    /**
+     * @var InsuranceSendCustomerCartHelper
+     */
+    private $insuranceSendCustomerCartHelper;
 
 
     protected function setUp(): void
@@ -51,6 +56,7 @@ class SalesOrderInvoicePayObserverTest extends TestCase
         $this->almaClient = $this->createMock(AlmaClient::class);
         $this->subscriptionResourceModel = $this->createMock(\Alma\MonthlyPayments\Model\Insurance\ResourceModel\Subscription::class);
         $this->apiConfigHelper = $this->createMock(ApiConfigHelper::class);
+        $this->insuranceSendCustomerCartHelper = $this->createMock(InsuranceSendCustomerCartHelper::class);
 
     }
 
@@ -66,6 +72,7 @@ class SalesOrderInvoicePayObserverTest extends TestCase
         $observer = $this->createMock(Observer::class);
         $observer->method('getEvent')->willReturn($event);
         $this->insuranceHelper->expects($this->once())->method('getSubscriberByAddress');
+        $this->insuranceSendCustomerCartHelper->expects($this->once())->method('sendCustomerCart')->with($itemsInvoiceCollection);
         $this->insuranceHelper->expects($this->once())->method('getSubscriptionData')->willReturn([]);
         $this->almaClient->expects($this->never())->method('getDefaultClient');
         $this->createSalesOrderInvoicePayObserver()->execute($observer);
@@ -94,6 +101,7 @@ class SalesOrderInvoicePayObserverTest extends TestCase
         $subscription2 = $this->createMock(\Alma\API\Entities\Insurance\Subscription::class);
 
         $this->insuranceHelper->expects($this->once())->method('getSubscriberByAddress')->willReturn($this->subscriberFactory());
+        $this->insuranceSendCustomerCartHelper->expects($this->once())->method('sendCustomerCart')->with($itemsInvoiceCollection);
         $this->insuranceHelper->expects($this->once())->method('getSubscriptionData')->willReturn([$subscription1, $subscription2]);
 
         $insuranceEndpoint = $this->createMock(Insurance::class);
@@ -126,6 +134,7 @@ class SalesOrderInvoicePayObserverTest extends TestCase
             $this->almaClient,
             $this->subscriptionResourceModel,
             $this->apiConfigHelper,
+            $this->insuranceSendCustomerCartHelper
         ];
     }
 

--- a/Test/Unit/Observer/SalesOrderInvoicePayObserverTest.php
+++ b/Test/Unit/Observer/SalesOrderInvoicePayObserverTest.php
@@ -112,7 +112,7 @@ class SalesOrderInvoicePayObserverTest extends TestCase
         $insuranceEndpoint = $this->createMock(Insurance::class);
         $insuranceEndpoint->expects($this->once())
             ->method('subscription')
-            ->with([$subscription1, $subscription2], null, null, '42')
+            ->with([$subscription1, $subscription2], null, null, 42)
             ->willReturn(json_decode('{"subscriptions":[{"contract_id":"insurance_contract_5LH0o7qj87xGp6sF1AGWqx","subscription_id":"subscription_298QYLM3q94luQSD34LDlr","cms_reference":"24-MB02"},{"contract_id":"insurance_contract_5LH0o7qj87xGp6sF1AGWqx","subscription_id":"subscription_2333333333333333333333","cms_reference":"24-MB02"}]}', true));
 
         $client = $this->createMock(Client::class);

--- a/Test/Unit/Observer/SalesOrderInvoicePayObserverTest.php
+++ b/Test/Unit/Observer/SalesOrderInvoicePayObserverTest.php
@@ -67,12 +67,17 @@ class SalesOrderInvoicePayObserverTest extends TestCase
         $invoice = $this->createMock(Invoice::class);
         $invoice->method('getBillingAddress')->willReturn($billingAddress);
         $invoice->method('getItems')->willReturn($itemsInvoiceCollection);
+
+        $orderMock = $this->createMock(Order::class);
+        $orderMock->method('getQuoteId')->willReturn(42);
+        $invoice->method('getOrder')->willReturn($orderMock);
+
         $event = $this->createMock(Event::class);
         $event->method('getData')->willReturn($invoice);
         $observer = $this->createMock(Observer::class);
         $observer->method('getEvent')->willReturn($event);
         $this->insuranceHelper->expects($this->once())->method('getSubscriberByAddress');
-        $this->insuranceSendCustomerCartHelper->expects($this->once())->method('sendCustomerCart')->with($itemsInvoiceCollection);
+        $this->insuranceSendCustomerCartHelper->expects($this->once())->method('sendCustomerCart')->with($itemsInvoiceCollection, 42);
         $this->insuranceHelper->expects($this->once())->method('getSubscriptionData')->willReturn([]);
         $this->almaClient->expects($this->never())->method('getDefaultClient');
         $this->createSalesOrderInvoicePayObserver()->execute($observer);
@@ -88,7 +93,7 @@ class SalesOrderInvoicePayObserverTest extends TestCase
         $invoice->method('getItems')->willReturn($itemsInvoiceCollection);
 
         $orderMock = $this->createMock(Order::class);
-        $orderMock->method('getQuoteId')->willReturn('42');
+        $orderMock->method('getQuoteId')->willReturn(42);
         $invoice->method('getOrder')->willReturn($orderMock);
 
         $event = $this->createMock(Event::class);
@@ -101,7 +106,7 @@ class SalesOrderInvoicePayObserverTest extends TestCase
         $subscription2 = $this->createMock(\Alma\API\Entities\Insurance\Subscription::class);
 
         $this->insuranceHelper->expects($this->once())->method('getSubscriberByAddress')->willReturn($this->subscriberFactory());
-        $this->insuranceSendCustomerCartHelper->expects($this->once())->method('sendCustomerCart')->with($itemsInvoiceCollection);
+        $this->insuranceSendCustomerCartHelper->expects($this->once())->method('sendCustomerCart')->with($itemsInvoiceCollection, 42);
         $this->insuranceHelper->expects($this->once())->method('getSubscriptionData')->willReturn([$subscription1, $subscription2]);
 
         $insuranceEndpoint = $this->createMock(Insurance::class);

--- a/composer.json
+++ b/composer.json
@@ -3,7 +3,7 @@
     "description": "Integrates Alma Monthly Payments into Magento 2",
     "require": {
         "php": ">=7.1",
-        "alma/alma-php-client": ">=2.0.2"
+        "alma/alma-php-client": ">=2.0.3"
     },
     "type": "magento2-module",
     "version": "4.1.1",


### PR DESCRIPTION
### Reason for change

<!-- Describe here the reason for change, and provide a link to the corresponding ClickUp task or Sentry issue. -->

Add call to a new sendcustomerCartHelper in observer and test.
New sendCustomerCartHelper who send cms_reference without ddoble conifgurable product and insurance product

[Linear task](https://linear.app/almapay/issue/ECOM-1336/[adobe-commerce]-call-endpoint-with-cms-reference)

### Code changes

<!-- Describe here the code changes at a high level. Anything that can help reviewers review your PR. -->

### How to test

_As a reviewer, you are encouraged to test the PR locally._

<!-- Describe here how to test your changes, if applicable. Insert UI screenshots when relevant -->

### Checklist for authors and reviewers

<!-- Move to the next section the non applicable items -->

- [ ] The title of the PR uses business wording, not technical jargon, for the changelog readers to understand it
- [ ] The PR implements the changes asked in the referenced task / issue
- [ ] The automated tests are compliant with the [testing strategy](https://www.notion.so/almapay/Backend-testing-strategy-06c642cec1bf47b9b8feca3a91ea8d4a)
- [ ] The tests are relevant, and cover the corner/error cases, not only the happy path
- [ ] You understand the impact of this PR on existing code/features
- [ ] The changes include adequate logging and Datadog traces
- [ ] Documentation is updated (API, developer documentation, ADR, Notion...)

### Non applicable

<!-- Move here non applicable items of the checklist, if any -->
