### PR TITLE
Feature/ecom 1348 add order id in subscription call to api adobe commerce

### DIFF
--- a/Observer/SalesOrderInvoicePayObserver.php
+++ b/Observer/SalesOrderInvoicePayObserver.php
@@ -77,7 +77,7 @@ class SalesOrderInvoicePayObserver implements ObserverInterface
         }
 
         try {
-            $return = $this->almaClient->getDefaultClient()->insurance->subscription($subscriptionArray, null, null, $invoice->getOrder()->getQuoteId());
+            $return = $this->almaClient->getDefaultClient()->insurance->subscription($subscriptionArray, $invoice->getOrder()->getId(), null, $invoice->getOrder()->getQuoteId());
             if (!$return['subscriptions']) {
                 $this->logger->error('Warning No subscription data in Alma return', [$return]);
                 return;

--- a/Test/Unit/Observer/SalesOrderInvoicePayObserverTest.php
+++ b/Test/Unit/Observer/SalesOrderInvoicePayObserverTest.php
@@ -85,6 +85,7 @@ class SalesOrderInvoicePayObserverTest extends TestCase
 
     public function testObserverMustCallGetSubscriberAndSubscriptionDataAndCallAlmaClientInsuranceSubscriptionAndPointAndSaveDataInDb(): void
     {
+        $orderId = 35;
         $billingAddress = $this->createMock(Address::class);
         $itemsInvoiceCollection = $this->createMock(Collection::class);
 
@@ -94,6 +95,7 @@ class SalesOrderInvoicePayObserverTest extends TestCase
 
         $orderMock = $this->createMock(Order::class);
         $orderMock->method('getQuoteId')->willReturn(42);
+        $orderMock->method('getId')->willReturn($orderId);
         $invoice->method('getOrder')->willReturn($orderMock);
 
         $event = $this->createMock(Event::class);
@@ -112,7 +114,7 @@ class SalesOrderInvoicePayObserverTest extends TestCase
         $insuranceEndpoint = $this->createMock(Insurance::class);
         $insuranceEndpoint->expects($this->once())
             ->method('subscription')
-            ->with([$subscription1, $subscription2], null, null, 42)
+            ->with([$subscription1, $subscription2], $orderId, null, 42)
             ->willReturn(json_decode('{"subscriptions":[{"contract_id":"insurance_contract_5LH0o7qj87xGp6sF1AGWqx","subscription_id":"subscription_298QYLM3q94luQSD34LDlr","cms_reference":"24-MB02"},{"contract_id":"insurance_contract_5LH0o7qj87xGp6sF1AGWqx","subscription_id":"subscription_2333333333333333333333","cms_reference":"24-MB02"}]}', true));
 
         $client = $this->createMock(Client::class);


### PR DESCRIPTION
### Reason for change

<!-- Describe here the reason for change, and provide a link to the corresponding ClickUp task or Sentry issue. -->
Add order id in subscription call
[Linear task](https://linear.app/almapay/issue/ECOM-1348/add-order-id-in-subscription-call-to-api-adobe-commerce)

### Code changes

<!-- Describe here the code changes at a high level. Anything that can help reviewers review your PR. -->

### How to test

_As a reviewer, you are encouraged to test the PR locally._

<!-- Describe here how to test your changes, if applicable. Insert UI screenshots when relevant -->

### Checklist for authors and reviewers

<!-- Move to the next section the non applicable items -->

- [ ] The title of the PR uses business wording, not technical jargon, for the changelog readers to understand it
- [ ] The PR implements the changes asked in the referenced task / issue
- [ ] The automated tests are compliant with the [testing strategy](https://www.notion.so/almapay/Backend-testing-strategy-06c642cec1bf47b9b8feca3a91ea8d4a)
- [ ] The tests are relevant, and cover the corner/error cases, not only the happy path
- [ ] You understand the impact of this PR on existing code/features
- [ ] The changes include adequate logging and Datadog traces
- [ ] Documentation is updated (API, developer documentation, ADR, Notion...)

### Non applicable

<!-- Move here non applicable items of the checklist, if any -->
