### PR TITLE
Adobe commerce remove broker id from subscription response

### DIFF
--- a/Helpers/InsuranceHelper.php
+++ b/Helpers/InsuranceHelper.php
@@ -417,7 +417,6 @@ class InsuranceHelper extends AbstractHelper
             $dbSubscription->setOrderItemId($orderItem->getItemId());
             $dbSubscription->setName($orderItemInsuranceData['name']);
             $dbSubscription->setSubscriptionId($subscriptionResultContractData['id']);
-            $dbSubscription->setSubscriptionBrokerId($subscriptionResultContractData['broker_subscription_id']);
             $dbSubscription->setSubscriptionAmount(intval($subscriptionResultContractData['amount']));
             $dbSubscription->setContractId($orderItemInsuranceData['id']);
             $dbSubscription->setCmsReference($subscriptionResultContractData['cms_reference']);

--- a/Test/Unit/Helpers/InsuranceHelperTest.php
+++ b/Test/Unit/Helpers/InsuranceHelperTest.php
@@ -628,7 +628,6 @@ class InsuranceHelperTest extends TestCase
                 "contract_id":"insurance_contract_5LH0o7qj87xGp6sF1AGWqx",
                 "id":"subscription_298QYLM3q94luQSD34LDlr",
                 "amount":"12312",
-                "broker_subscription_id":"provider_subscription_298QYLM3q94luQSD34LDlr",
                 "cms_reference":"24-MB02",
                 "state":"started"
                 },
@@ -649,7 +648,6 @@ class InsuranceHelperTest extends TestCase
                 'order_item_id' => 23,
                 'name' => 'Alma outillage thermique 3 ans (Vol + casse)',
                 'subscription_id' => 'subscription_298QYLM3q94luQSD34LDlr',
-                'subscription_broker_id' => 'provider_subscription_298QYLM3q94luQSD34LDlr',
                 'subscription_amount' => 12312,
                 'contract_id' => 'insurance_contract_5LH0o7qj87xGp6sF1AGWqx',
                 'cms_reference' => '24-MB02',
@@ -664,7 +662,6 @@ class InsuranceHelperTest extends TestCase
                 'order_item_id' => 25,
                 'name' => 'Alma outillage thermique 3 ans (Vol + casse)',
                 'subscription_id' => 'subscription_2333333333333333333333',
-                'subscription_broker_id' => 'provider_subscription_2333333333333333333333',
                 'subscription_amount' => 12456,
                 'contract_id' => 'insurance_contract_5LH0o7qj87xGp6sF1AGWqx',
                 'cms_reference' => '24-MB02',


### PR DESCRIPTION
### Reason for change

<!-- Describe here the reason for change, and provide a link to the corresponding ClickUp task or Sentry issue. -->
Remove broker id from api response.
Broker id will be set with async webhook -> controller update
[Linear task](https://linear.app/almapay/issue/ECOM-1354/[adobecommerce]-remove-broker-id-from-subscription-creation-response)

### Code changes

<!-- Describe here the code changes at a high level. Anything that can help reviewers review your PR. -->

### How to test

_As a reviewer, you are encouraged to test the PR locally._

<!-- Describe here how to test your changes, if applicable. Insert UI screenshots when relevant -->

### Checklist for authors and reviewers

<!-- Move to the next section the non applicable items -->

- [ ] The title of the PR uses business wording, not technical jargon, for the changelog readers to understand it
- [ ] The PR implements the changes asked in the referenced task / issue
- [ ] The automated tests are compliant with the [testing strategy](https://www.notion.so/almapay/Backend-testing-strategy-06c642cec1bf47b9b8feca3a91ea8d4a)
- [ ] The tests are relevant, and cover the corner/error cases, not only the happy path
- [ ] You understand the impact of this PR on existing code/features
- [ ] The changes include adequate logging and Datadog traces
- [ ] Documentation is updated (API, developer documentation, ADR, Notion...)

### Non applicable

<!-- Move here non applicable items of the checklist, if any -->
