### PR TITLE
Feature/ecom 1317 create controller for adobe commerce

### DIFF
--- a/Block/Adminhtml/Insurance/SubscriptionDetails.php
+++ b/Block/Adminhtml/Insurance/SubscriptionDetails.php
@@ -8,6 +8,8 @@ use Alma\MonthlyPayments\Helpers\Logger;
 use Alma\MonthlyPayments\Model\Insurance\ResourceModel\Subscription\Collection;
 use Alma\MonthlyPayments\Model\Insurance\ResourceModel\Subscription\CollectionFactory;
 use Magento\Backend\Block\Template;
+use Magento\Backend\Block\Template\Context;
+use Magento\Backend\Model\Url;
 use Magento\Directory\Helper\Data as DirectoryHelper;
 use Magento\Framework\Exception\InputException;
 use Magento\Framework\Exception\NoSuchEntityException;
@@ -37,7 +39,20 @@ class SubscriptionDetails extends Template
      * @var OrderRepository
      */
     private $orderRepository;
+    private $urlBuilder;
 
+    /**
+     * @param Logger $logger
+     * @param Context $context
+     * @param InsuranceHelper $insuranceHelper
+     * @param ApiConfigHelper $apiConfigHelper
+     * @param CollectionFactory $collectionFactory
+     * @param OrderRepository $orderRepository
+     * @param Url $urlBuilder
+     * @param array $data
+     * @param JsonHelper|null $jsonHelper
+     * @param DirectoryHelper|null $directoryHelper
+     */
     public function __construct(
         Logger            $logger,
         Template\Context  $context,
@@ -45,6 +60,7 @@ class SubscriptionDetails extends Template
         ApiConfigHelper   $apiConfigHelper,
         CollectionFactory $collectionFactory,
         OrderRepository   $orderRepository,
+        Url               $urlBuilder,
         array             $data = [],
         ?JsonHelper       $jsonHelper = null,
         ?DirectoryHelper  $directoryHelper = null
@@ -61,6 +77,7 @@ class SubscriptionDetails extends Template
         $this->logger = $logger;
         $this->collectionFactory = $collectionFactory;
         $this->orderRepository = $orderRepository;
+        $this->urlBuilder = $urlBuilder;
     }
 
     /**
@@ -68,10 +85,15 @@ class SubscriptionDetails extends Template
      */
     public function getScriptUrl(): string
     {
+        //TODO : Remove staging URL
         return 'https://protect.staging.almapay.com/displayModal.js';
-        //return $this->insuranceHelper->getScriptUrl($this->apiConfigHelper->getActiveMode());
+        return $this->insuranceHelper->getScriptUrl($this->apiConfigHelper->getActiveMode());
     }
 
+    public function getControllerCancelUrl(): string
+    {
+        return $this->urlBuilder->getUrl('alma_monthly/insurance/cancelsubscription');
+    }
     /**
      * @return array
      */

--- a/Block/Adminhtml/Insurance/SubscriptionDetails.php
+++ b/Block/Adminhtml/Insurance/SubscriptionDetails.php
@@ -85,8 +85,6 @@ class SubscriptionDetails extends Template
      */
     public function getScriptUrl(): string
     {
-        //TODO : Remove staging URL
-        return 'https://protect.staging.almapay.com/displayModal.js';
         return $this->insuranceHelper->getScriptUrl($this->apiConfigHelper->getActiveMode());
     }
 

--- a/Controller/Adminhtml/Insurance/CancelSubscription.php
+++ b/Controller/Adminhtml/Insurance/CancelSubscription.php
@@ -1,0 +1,88 @@
+<?php
+
+namespace Alma\MonthlyPayments\Controller\Adminhtml\Insurance;
+
+use Alma\API\Entities\Insurance\Subscription;
+use Alma\API\Exceptions\AlmaException;
+use Alma\API\Exceptions\InsuranceCancelPendingException;
+use Alma\MonthlyPayments\Helpers\AlmaClient;
+use Alma\MonthlyPayments\Helpers\InsuranceSubscriptionHelper;
+use Alma\MonthlyPayments\Helpers\Logger;
+use Magento\Backend\App\Action;
+use Magento\Backend\App\Action\Context;
+use Magento\Framework\Controller\Result\Json;
+use Magento\Framework\Controller\Result\JsonFactory;
+
+
+class CancelSubscription extends Action
+{
+    const NO_SUBSCRIPTION_ID_MESSAGE = 'No subscription Id in post data';
+    const CANCEL_ERROR_MESSAGE = 'Impossible to cancel subscription';
+    const CANCEL_SUCCESS_MESSAGE = 'Subscription cancelled';
+    const CANCEL_PENDING_MESSAGE = 'Out of delay to cancel subscription';
+
+    private $resultJsonFactory;
+    private $logger;
+    private $almaClient;
+    private $subscriptionResourceModel;
+    private $insuranceSubscriptionHelper;
+
+
+    /**
+     * @param Logger $logger
+     * @param JsonFactory $resultJsonFactory
+     * @param Context $context
+     */
+    public function __construct(
+        AlmaClient  $almaClient,
+        InsuranceSubscriptionHelper $insuranceSubscriptionHelper,
+        \Alma\MonthlyPayments\Model\Insurance\ResourceModel\Subscription $subscriptionResourceModel,
+        Logger      $logger,
+        JsonFactory $resultJsonFactory,
+        Context     $context
+    )
+    {
+        parent::__construct(
+            $context
+        );
+        $this->resultJsonFactory = $resultJsonFactory;
+        $this->logger = $logger;
+        $this->almaClient = $almaClient;
+        $this->subscriptionResourceModel = $subscriptionResourceModel;
+        $this->insuranceSubscriptionHelper = $insuranceSubscriptionHelper;
+    }
+
+    public function execute(): Json
+    {
+        $result = $this->resultJsonFactory->create();
+        $response = ['state' => Subscription::STATE_CANCELLED, 'message' => self::CANCEL_SUCCESS_MESSAGE];
+
+        $post = $this->getRequest()->getPostValue();
+        if (empty($post) || !is_array($post) || !array_key_exists('subscriptionId', $post)) {
+            $response = ['state' => Subscription::STATE_FAILED, 'message' => self::NO_SUBSCRIPTION_ID_MESSAGE];
+            return $result->setData($response);
+        }
+
+
+
+        try {
+            $this->almaClient->getDefaultClient()->insurance->cancelSubscription($post['subscriptionId']);
+        } catch (InsuranceCancelPendingException $e) {
+            $response = ['state' => Subscription::STATE_PENDING_CANCELLATION, 'message' => self::CANCEL_PENDING_MESSAGE];
+        } catch (AlmaException $e) {
+            $this->logger->error('Error cancelling subscription', [$e->getMessage()]);
+            $response = ['state' => Subscription::STATE_FAILED, 'message' => self::CANCEL_ERROR_MESSAGE];
+        }
+
+        try {
+            $dbSubscription = $this->insuranceSubscriptionHelper->getDbSubscription($post['subscriptionId']);
+            $dbSubscription->setSubscriptionState($response['state']);
+            $this->subscriptionResourceModel->save($dbSubscription);
+        } catch (\Exception $e) {
+            $this->logger->error('Impossible to load/save Subscription', [$post['subscriptionId']]);
+        }
+
+        return $result->setData($response);
+    }
+
+}

--- a/Helpers/InsuranceSubscriptionHelper.php
+++ b/Helpers/InsuranceSubscriptionHelper.php
@@ -1,0 +1,40 @@
+<?php
+
+namespace Alma\MonthlyPayments\Helpers;
+
+use Alma\MonthlyPayments\Model\Insurance\ResourceModel\Subscription\CollectionFactory;
+use Alma\MonthlyPayments\Model\Insurance\Subscription;
+use Magento\Framework\App\Helper\AbstractHelper;
+use Magento\Framework\App\Helper\Context;
+use Magento\Framework\Validator\Exception;
+
+class InsuranceSubscriptionHelper extends AbstractHelper
+{
+    private $subscriptionCollection;
+    public function __construct(
+        CollectionFactory $subscriptionCollection,
+        Context $context
+    ) {
+        parent::__construct($context);
+        $this->subscriptionCollection = $subscriptionCollection;
+    }
+
+    /**
+     * @param mixed $subscriptionId
+     * @return mixed
+     * @throws Exception
+     */
+    public function getDbSubscription(mixed $subscriptionId): Subscription
+    {
+        $collection = $this->subscriptionCollection->create();
+        $collection->addFieldToFilter('subscription_id', $subscriptionId);
+        $this->checkSubscriptionExistInDb($collection);
+        return $collection->getFirstItem();
+    }
+    private function checkSubscriptionExistInDb($collection): void
+    {
+        if (!$collection->getFirstItem()->getId()) {
+            throw new Exception(__('Subscription not found'));
+        }
+    }
+}

--- a/Model/Api/Insurance/InsuranceUpdate.php
+++ b/Model/Api/Insurance/InsuranceUpdate.php
@@ -6,9 +6,9 @@ use Alma\API\Exceptions\AlmaException;
 use Alma\MonthlyPayments\Api\Insurance\InsuranceUpdateInterface;
 use Alma\MonthlyPayments\Helpers\AlmaClient;
 use Alma\MonthlyPayments\Helpers\Functions;
+use Alma\MonthlyPayments\Helpers\InsuranceSubscriptionHelper;
 use Alma\MonthlyPayments\Helpers\Logger;
 use Alma\MonthlyPayments\Model\Insurance\ResourceModel\Subscription;
-use Alma\MonthlyPayments\Model\Insurance\ResourceModel\Subscription\CollectionFactory;
 use Magento\Backend\Model\Url;
 use Magento\Framework\Exception\AlreadyExistsException;
 use Magento\Framework\Notification\NotifierPool;
@@ -27,10 +27,10 @@ class InsuranceUpdate implements InsuranceUpdateInterface
      */
     private $request;
     private $almaClient;
-    private CollectionFactory $subscriptionCollection;
-    private Subscription $subscription;
-    private NotifierPool $notifierPool;
-    private OrderRepository $orderRepository;
+    private $insuranceSubscriptionHelper;
+    private $subscription;
+    private $notifierPool;
+    private $orderRepository;
     private Url $url;
 
     /**
@@ -38,24 +38,23 @@ class InsuranceUpdate implements InsuranceUpdateInterface
      * @param Logger $logger
      */
     public function __construct(
-        Request           $request,
-        Logger            $logger,
-        AlmaClient        $almaClient,
-        CollectionFactory $subscriptionCollection,
-        Subscription      $subscription,
-        NotifierPool      $notifierPool,
-        OrderRepository   $orderRepository,
-        Url               $url
-    )
-    {
+        Request                     $request,
+        Logger                      $logger,
+        AlmaClient                  $almaClient,
+        InsuranceSubscriptionHelper $insuranceSubscriptionHelper,
+        Subscription                $subscription,
+        NotifierPool                $notifierPool,
+        OrderRepository             $orderRepository,
+        Url                         $url
+    ) {
         $this->request = $request;
         $this->logger = $logger;
         $this->almaClient = $almaClient;
-        $this->subscriptionCollection = $subscriptionCollection;
         $this->subscription = $subscription;
         $this->notifierPool = $notifierPool;
         $this->orderRepository = $orderRepository;
         $this->url = $url;
+        $this->insuranceSubscriptionHelper = $insuranceSubscriptionHelper;
     }
 
     /**
@@ -72,7 +71,11 @@ class InsuranceUpdate implements InsuranceUpdateInterface
         $this->checkSubscriptionResponseNotEmpty($subscriptions['subscriptions']);
 
         $subscription = $subscriptions['subscriptions'][0];
-        $dbSubscription = $this->getDbSubscription($subscriptionId);
+        try {
+            $dbSubscription = $this->insuranceSubscriptionHelper->getDbSubscription($subscriptionId);
+        } catch (\Magento\Framework\Validator\Exception $e) {
+            throw new Exception(__('Invalid subscription_id'), 0, 404);
+        }
 
         $dbSubscription->setSubscriptionState($subscription['state']);
         $dbSubscription->setSubscriptionBrokerId($subscription['broker_subscription_id']);
@@ -81,7 +84,7 @@ class InsuranceUpdate implements InsuranceUpdateInterface
         } catch (AlreadyExistsException|\Exception $e) {
             throw new Exception(__('Impossible to save subscription data'), 0, 500);
         }
-        if (\Alma\API\Entities\Insurance\Subscription::STATE_STARTED === $subscription['state']) {
+        if (\Alma\API\Entities\Insurance\Subscription::STATE_CANCELLED === $subscription['state']) {
             $order = $this->orderRepository->get($dbSubscription->getOrderId());
             $this->notifierPool->addMajor(
                 sprintf(__('Alma Insurance: Order %s - Cancelled insurance subscriptions need to be refunded'), $order->getIncrementId()),
@@ -137,21 +140,8 @@ class InsuranceUpdate implements InsuranceUpdateInterface
             $subscriptions = $this->almaClient->getDefaultClient()->insurance->getSubscription(['id' => $subscriptionId]);
         } catch (AlmaException $e) {
             $this->logger->error("Error getting subscription:", [$e->getMessage()]);
-            throw new Exception(__('Impossible to get subscription_id'), 0, 404,);
+            throw new Exception(__('Impossible to get subscription_id'), 0, 404, );
         }
         return $subscriptions;
-    }
-
-    /**
-     * @param mixed $subscriptionId
-     * @return \Alma\MonthlyPayments\Model\Insurance\Subscription
-     * @throws Exception
-     */
-    public function getDbSubscription(mixed $subscriptionId)
-    {
-        $collection = $this->subscriptionCollection->create();
-        $collection->addFieldToFilter('subscription_id', $subscriptionId);
-        $this->checkSubscriptionExistInDb($collection);
-        return $collection->getFirstItem();
     }
 }

--- a/Model/Insurance/Subscription.php
+++ b/Model/Insurance/Subscription.php
@@ -268,7 +268,7 @@ class Subscription extends AbstractModel implements IdentityInterface
      * @param string|null $date
      * @return void
      */
-    public function setCancellationDate(string $date = null): void
+    public function setCancellationDate(\DateTime $date = null): void
     {
         $this->setData(self::CANCELATION_DATE_KEY, $date);
     }
@@ -302,7 +302,7 @@ class Subscription extends AbstractModel implements IdentityInterface
      * @param string|null $date
      * @return void
      */
-    public function setCancellationRequestDate(string $date = null): void
+    public function setCancellationRequestDate(\DateTime $date = null): void
     {
         $this->setData(self::CANCELATION_REQUEST_DATE_KEY, $date);
     }

--- a/Model/Insurance/Subscription.php
+++ b/Model/Insurance/Subscription.php
@@ -259,7 +259,7 @@ class Subscription extends AbstractModel implements IdentityInterface
     /**
      * @return string|null
      */
-    public function getCancellationDate(): ?string
+    public function getCancellationDate(): ?\DateTime
     {
         return $this->getDataByKey(self::CANCELATION_DATE_KEY);
     }
@@ -293,7 +293,7 @@ class Subscription extends AbstractModel implements IdentityInterface
     /**
      * @return string|null
      */
-    public function getCancellationRequestDate(): ?string
+    public function getCancellationRequestDate(): ?\DateTime
     {
         return $this->getDataByKey(self::CANCELATION_REQUEST_DATE_KEY);
     }

--- a/Test/Unit/Controller/Adminhtml/Insurance/CancelSubscriptionTest.php
+++ b/Test/Unit/Controller/Adminhtml/Insurance/CancelSubscriptionTest.php
@@ -1,0 +1,193 @@
+<?php
+
+namespace Alma\MonthlyPayments\Test\Unit\Controller\Adminhtml\Insurance;
+
+use Alma\API\Client;
+use Alma\API\Endpoints\Insurance;
+use Alma\API\Exceptions\InsuranceCancelPendingException;
+use Alma\API\Exceptions\RequestException;
+use Alma\MonthlyPayments\Controller\Adminhtml\Insurance\CancelSubscription;
+use Alma\MonthlyPayments\Helpers\AlmaClient;
+use Alma\MonthlyPayments\Helpers\InsuranceSubscriptionHelper;
+use Alma\MonthlyPayments\Helpers\Logger;
+use Alma\MonthlyPayments\Model\Insurance\ResourceModel\Subscription;
+use Magento\Backend\App\Action\Context;
+use Magento\Framework\App\RequestInterface;
+use Magento\Framework\Controller\Result\Json;
+use Magento\Framework\Controller\Result\JsonFactory;
+use Magento\Framework\HTTP\PhpEnvironment\Request;
+use PHPUnit\Framework\TestCase;
+
+class CancelSubscriptionTest extends TestCase
+{
+
+    /**
+     * @var Context
+     */
+    private $context;
+    /**
+     * @var JsonFactory
+     */
+    private $jsonFactory;
+    /**
+     * @var Logger
+     */
+    private $logger;
+    /**
+     * @var RequestInterface
+     */
+    private $request;
+    /**
+     * @var Json
+     */
+    private $jsonResponse;
+    /**
+     * @var AlmaClient
+     */
+    private $almaClient;
+    /**
+     * @var Insurance
+     */
+    private $insuranceMock;
+    /**
+     * @var Subscription
+     */
+    private $subscriptionResourceModel;
+    private $dbSubscriptionMock;
+    private $insuranceSubscriptionHelper;
+    protected function setUp(): void
+    {
+        $this->context = $this->createMock(Context::class);
+        $this->request = $this->createMock(Request::class);
+        $this->context->method('getRequest')->willReturn($this->request);
+        $this->jsonResponse = $this->createMock(Json::class);
+        $this->jsonResponse->method('setData')->willReturn($this->jsonResponse);
+        $this->jsonFactory = $this->createMock(JsonFactory::class);
+        $this->jsonFactory->method('create')->willReturn($this->jsonResponse);
+        $this->logger = $this->createMock(Logger::class);
+        $this->insuranceMock = $this->createMock(Insurance::class);
+        $client = $this->createMock(Client::class);
+        $client->insurance = $this->insuranceMock;
+        $this->almaClient = $this->createMock(AlmaClient::class);
+        $this->almaClient->method('getDefaultClient')->willReturn($client);
+        $this->dbSubscriptionMock = $this->createMock(\Alma\MonthlyPayments\Model\Insurance\Subscription::class);
+        $this->subscriptionResourceModel = $this->createMock(Subscription::class);
+        $this->insuranceSubscriptionHelper = $this->createMock(InsuranceSubscriptionHelper::class);
+        $this->insuranceSubscriptionHelper->method('getDbSubscription')->willReturn($this->dbSubscriptionMock);
+    }
+
+    public function tearDown():void
+    {
+        $this->dbSubscriptionMock = null;
+    }
+
+    protected function newCancelSubscription(): CancelSubscription
+    {
+        return new CancelSubscription(
+            $this->almaClient,
+            $this->insuranceSubscriptionHelper,
+            $this->subscriptionResourceModel,
+            $this->logger,
+            $this->jsonFactory,
+            $this->context,
+        );
+    }
+
+    //Given an empty post request
+    public function testShouldReturnAnErrorMessageWhenRequestIsEmpty()
+    {
+        $this->request->method('getPostValue')->willReturn([]);
+        $this->jsonResponse->expects($this->once())->method('setData')->with(['state' => 'failed', 'message' => CancelSubscription::NO_SUBSCRIPTION_ID_MESSAGE]);
+        $this->newCancelSubscription()->execute();
+    }
+
+    //Given a request with post data when subscriptionId is missing
+    public function testShouldReturnAnErrorMessageWhenSubscriptionIdIsMissing()
+    {
+        $this->request->method('getPostValue')->willReturn(['subscriptionBrokerId' => '123']);
+        $this->jsonResponse->expects($this->once())->method('setData')->with(['state' => 'failed', 'message' => CancelSubscription::NO_SUBSCRIPTION_ID_MESSAGE]);
+        $this->newCancelSubscription()->execute();
+    }
+
+    // Given a request with post data when subscriptionId is present and Api Error
+    public function testShouldCallApiClientCancelEndpointWithSubscriptionIdAndReturnAnError()
+    {
+        $subscriptionId = 'subscription_id1234';
+        $this->request->method('getPostValue')->willReturn(['subscriptionId' => $subscriptionId]);
+
+        $this->insuranceMock
+            ->expects($this->once())
+            ->method('cancelSubscription')
+            ->with($subscriptionId)
+            ->willThrowException(new RequestException('Error cancelling subscription'));
+
+        $this->jsonResponse->expects($this->once())->method('setData')->with(['state' => 'failed', 'message' => CancelSubscription::CANCEL_ERROR_MESSAGE]);
+
+        $this->newCancelSubscription()->execute();
+    }
+
+    //Given a request with post data when subscriptionId is present and Api success Load throw an exception
+    public function testShouldCallApiClientCancelEndpointWithSubscriptionIdAndReturnSuccessWithErrorOnLoad()
+    {
+        $subscriptionId = 'subscription_id123456';
+        $this->request->method('getPostValue')->willReturn(['subscriptionId' => $subscriptionId]);
+
+        $this->insuranceMock
+            ->expects($this->once())
+            ->method('cancelSubscription')
+            ->with($subscriptionId);
+
+        $this->jsonResponse->expects($this->once())->method('setData')->with(['state' => 'canceled', 'message' => CancelSubscription::CANCEL_SUCCESS_MESSAGE]);
+        $this->newCancelSubscription()->execute();
+    }
+    public function testShouldCallApiClientCancelEndpointWithSubscriptionIdAndReturnSuccessWithErrorOnSave()
+    {
+        $subscriptionId = 'subscription_id123456';
+        $this->request->method('getPostValue')->willReturn(['subscriptionId' => $subscriptionId]);
+
+        $this->insuranceMock
+            ->expects($this->once())
+            ->method('cancelSubscription')
+            ->with($subscriptionId);
+        $this->dbSubscriptionMock->method('getId')->willReturn(1);
+        $this->subscriptionResourceModel->expects($this->once())->method('save')->with($this->dbSubscriptionMock)->willThrowException(new \Exception('Impossible to save subscription data'));
+        $this->jsonResponse->expects($this->once())->method('setData')->with(['state' => 'canceled', 'message' => CancelSubscription::CANCEL_SUCCESS_MESSAGE]);
+        $this->newCancelSubscription()->execute();
+    }
+    // Given a request with post data when subscriptionId is present and Api success
+    public function testShouldCallApiClientCancelEndpointWithSubscriptionIdAndReturnSuccess()
+    {
+        $subscriptionId = 'subscription_id123456';
+        $this->request->method('getPostValue')->willReturn(['subscriptionId' => $subscriptionId]);
+
+        $this->insuranceMock
+            ->expects($this->once())
+            ->method('cancelSubscription')
+            ->with($subscriptionId);
+        $this->dbSubscriptionMock->method('getId')->willReturn(1);
+        $this->dbSubscriptionMock->expects($this->once())->method('setSubscriptionState')->with('canceled');
+        $this->subscriptionResourceModel->expects($this->once())->method('save')->with($this->dbSubscriptionMock);
+        $this->jsonResponse->expects($this->once())->method('setData')->with(['state' => 'canceled', 'message' => CancelSubscription::CANCEL_SUCCESS_MESSAGE]);
+        $this->newCancelSubscription()->execute();
+    }
+    // Given a request with post data when subscriptionId is present and Api return 410 and throw InsuranceCancelPendingException out of delay
+    public function testShouldCallApiClientCancelEndpointWithSubscriptionIdAndReturnStatePendingCancellation()
+    {
+        $subscriptionId = 'subscription_id1234';
+        $this->request->method('getPostValue')->willReturn(['subscriptionId' => $subscriptionId]);
+
+        $this->insuranceMock
+            ->expects($this->once())
+            ->method('cancelSubscription')
+            ->with($subscriptionId)
+            ->willThrowException(new InsuranceCancelPendingException('Out of delay'));
+
+        $this->dbSubscriptionMock->method('getId')->willReturn(1);
+        $this->dbSubscriptionMock->expects($this->once())->method('setSubscriptionState')->with('pending_cancellation');
+        $this->subscriptionResourceModel->expects($this->once())->method('save')->with($this->dbSubscriptionMock);
+        $this->jsonResponse->expects($this->once())->method('setData')->with(['state' => 'pending_cancellation', 'message' => CancelSubscription::CANCEL_PENDING_MESSAGE]);
+
+        $this->newCancelSubscription()->execute();
+    }
+
+}

--- a/Test/Unit/Helpers/InsuranceSubscriptionHelperTest.php
+++ b/Test/Unit/Helpers/InsuranceSubscriptionHelperTest.php
@@ -1,0 +1,49 @@
+<?php
+
+namespace Alma\MonthlyPayments\Test\Unit\Helpers;
+
+use Alma\MonthlyPayments\Model\Insurance\ResourceModel\Subscription\Collection;
+use Alma\MonthlyPayments\Model\Insurance\ResourceModel\Subscription\CollectionFactory;
+use Alma\MonthlyPayments\Model\Insurance\Subscription;
+use Magento\Framework\App\Helper\Context;
+use PHPUnit\Framework\TestCase;
+
+class InsuranceSubscriptionHelperTest extends TestCase
+{
+
+
+    private $subscriptionMock;
+    private $collectionMock;
+    private $collectionFactory;
+    private $context;
+    private $subscriptionHelper;
+
+    protected function setUp(): void
+    {
+        $this->subscriptionMock = $this->createMock(Subscription::class);
+        $this->collectionMock = $this->createMock(Collection::class);
+        $this->collectionMock->method('addFieldToFilter')->willReturn($this->collectionMock);
+        $this->collectionMock->method('getFirstItem')->willReturn($this->subscriptionMock);
+        $this->collectionFactory = $this->createMock(CollectionFactory::class);
+        $this->collectionFactory->method('create')->willReturn($this->collectionMock);
+        $this->context = $this->createMock(Context::class);
+        $this->subscriptionHelper = new \Alma\MonthlyPayments\Helpers\InsuranceSubscriptionHelper($this->collectionFactory, $this->context);
+
+    }
+
+    // Givent a unknown subscription id when getDbSubscription then throw exception
+    public function testShouldReturnAValidatorExceptionForAnEmptySubscriptionId()
+    {
+        $this->expectException(\Magento\Framework\Validator\Exception::class);
+        $this->expectExceptionMessage('Subscription not found');
+        $this->subscriptionMock->method('getId')->willReturn(null);
+        $this->subscriptionHelper->getDbSubscription(1);
+    }
+    //Given a known subscription id when getDbSubscription then return the subscription
+    public function testShouldReturnASubscriptionForAValidSubscriptionId()
+    {
+        $this->subscriptionMock->method('getId')->willReturn(1);
+        $this->assertEquals($this->subscriptionMock, $this->subscriptionHelper->getDbSubscription(1));
+    }
+
+}

--- a/view/adminhtml/templates/insurance/subscription/details.phtml
+++ b/view/adminhtml/templates/insurance/subscription/details.phtml
@@ -26,7 +26,8 @@
                 "orderDate": "<?= $block->getOrderDate() ?>",
                 "firstName": "<?= $block->getCustomerFirstName() ?>",
                 "lastName": "<?= $block->getCustomerLastName() ?>",
-                "subscriptions": <?=  json_encode($block->getSubscriptionCollection(), true) ?>
+                "subscriptions": <?=  json_encode($block->getSubscriptionCollection(), true) ?>,
+                "controllerCancelUrl": "<?= $block->getControllerCancelUrl() ?>"
             }
         }
     }

--- a/view/adminhtml/ui_component/subscription_grid_listing.xml
+++ b/view/adminhtml/ui_component/subscription_grid_listing.xml
@@ -100,13 +100,14 @@
                 <label translate="true">State</label>
             </settings>
         </column>
-        <column name="cancellation_date">
+        <column name="date_of_cancelation">
             <settings>
                 <label translate="true">Cancellation Date</label>
             </settings>
         </column>
-        <column name="cancellation_reason" >
+        <column name="reason_of_cancelation">
             <settings>
+                <filter>text</filter>
                 <label translate="true">Cancellation Reason</label>
             </settings>
         </column>

--- a/view/adminhtml/web/js/subscription_details.js
+++ b/view/adminhtml/web/js/subscription_details.js
@@ -56,18 +56,18 @@ define([
                 return subscriptions.map(subscription => {
                     console.log(subscription);
                     return {
-                        subscriptionId: subscription.subscription_id,
                         id: subscription.entity_id,
                         productName: subscription.linked_product_name,
+                        productPrice: subscription.linked_product_price,
                         insuranceName: subscription.name,
                         status: subscription.subscription_state,
-                        productPrice: subscription.linked_product_price,
+                        subscriptionId: subscription.subscription_id,
+                        subscriptionBrokerId: subscription.subscription_broker_id,
                         subscriptionAmount: subscription.subscription_amount,
                         isRefunded: subscription.is_refunded === '1',
                         reasonForCancelation: subscription.reason_of_cancelation,
                         dateOfCancelation: subscription.date_of_cancelation,
                         dateOfCancelationRequest: subscription.date_of_cancelation_request,
-                        subscriptionBrokerId: subscription.subscription_broker_id,
                     }
                 })
             }


### PR DESCRIPTION
### Reason for change

<!-- Describe here the reason for change, and provide a link to the corresponding ClickUp task or Sentry issue. -->

Add a backend controller ajax for voiding insurance

[Linear task](https://linear.app/almapay/issue/ECOM-1317/[🧩-ac]-create-controller-for-adobe-commerce)

### Code changes

<!-- Describe here the code changes at a high level. Anything that can help reviewers review your PR. -->

### How to test

_As a reviewer, you are encouraged to test the PR locally._

<!-- Describe here how to test your changes, if applicable. Insert UI screenshots when relevant -->

### Checklist for authors and reviewers

<!-- Move to the next section the non applicable items -->

- [ ] The title of the PR uses business wording, not technical jargon, for the changelog readers to understand it
- [ ] The PR implements the changes asked in the referenced task / issue
- [ ] The automated tests are compliant with the [testing strategy](https://www.notion.so/almapay/Backend-testing-strategy-06c642cec1bf47b9b8feca3a91ea8d4a)
- [ ] The tests are relevant, and cover the corner/error cases, not only the happy path
- [ ] You understand the impact of this PR on existing code/features
- [ ] The changes include adequate logging and Datadog traces
- [ ] Documentation is updated (API, developer documentation, ADR, Notion...)

### Non applicable

<!-- Move here non applicable items of the checklist, if any -->
