### PR TITLE
fix return type for getCancellationDate

### DIFF
--- a/Model/Insurance/Subscription.php
+++ b/Model/Insurance/Subscription.php
@@ -259,7 +259,7 @@ class Subscription extends AbstractModel implements IdentityInterface
     /**
      * @return string|null
      */
-    public function getCancellationDate(): ?\DateTime
+    public function getCancellationDate(): ?string
     {
         return $this->getDataByKey(self::CANCELATION_DATE_KEY);
     }

--- a/Test/Unit/Model/Api/Insurance/InsuranceUpdateTest.php
+++ b/Test/Unit/Model/Api/Insurance/InsuranceUpdateTest.php
@@ -201,7 +201,7 @@ class InsuranceUpdateTest extends TestCase
 
         $this->orderRepository->method('get')->willReturn($orderMock);
 
-        $this->dbSubscriptionMock->method('getCancellationDate')->willReturn(new \DateTime());
+        $this->dbSubscriptionMock->method('getCancellationDate')->willReturn('2024:09:01-00:00:00');
         $this->almaClient->method('getDefaultClient')->willReturn($this->client);
         $this->dbSubscriptionMock->expects($this->never())->method('setCancellationDate');
         $instance = $this->createInstance();


### PR DESCRIPTION
### Reason for change

<!-- Describe here the reason for change, and provide a link to the corresponding ClickUp task or Sentry issue. -->
Change getCancellationDate return type to string or null
[Linear task](https://linear.app/almapay/issue/ECOM-1236/[🧩-ac]-calls-get-subscription-to-confirm-or-mismatch)

### Code changes

<!-- Describe here the code changes at a high level. Anything that can help reviewers review your PR. -->

### How to test

_As a reviewer, you are encouraged to test the PR locally._

<!-- Describe here how to test your changes, if applicable. Insert UI screenshots when relevant -->

### Checklist for authors and reviewers

<!-- Move to the next section the non applicable items -->

- [ ] The title of the PR uses business wording, not technical jargon, for the changelog readers to understand it
- [ ] The PR implements the changes asked in the referenced task / issue
- [ ] The automated tests are compliant with the [testing strategy](https://www.notion.so/almapay/Backend-testing-strategy-06c642cec1bf47b9b8feca3a91ea8d4a)
- [ ] The tests are relevant, and cover the corner/error cases, not only the happy path
- [ ] You understand the impact of this PR on existing code/features
- [ ] The changes include adequate logging and Datadog traces
- [ ] Documentation is updated (API, developer documentation, ADR, Notion...)

### Non applicable

<!-- Move here non applicable items of the checklist, if any -->
