### PR TITLE
fix: use order item QTY to create subscription

### DIFF
--- a/Helpers/InsuranceHelper.php
+++ b/Helpers/InsuranceHelper.php
@@ -361,23 +361,27 @@ class InsuranceHelper extends AbstractHelper
         foreach ($itemsCollection as $item) {
             /** @var \Magento\Sales\Model\Order\Item $orderItem */
             $orderItem = $item->getOrderItem();
+            $orderItemQty = (int)$item->getQty();
             $insuranceData = $orderItem->getData(InsuranceHelper::ALMA_INSURANCE_DB_KEY);
             if (!$insuranceData || $item->getSku() === InsuranceHelper::ALMA_INSURANCE_SKU) {
                 continue;
             }
             $insuranceData = json_decode($insuranceData, true);
-            try {
-                $subscriptionArray[] = new Subscription(
-                    $insuranceData['id'],
-                    $insuranceData['price'],
-                    $item->getSku(),
-                    Functions::priceToCents($orderItem->getOriginalPrice()),
-                    $subscriber,
-                    $this->getCallbackUrl()
-                );
-            } catch (\Exception $e) {
-                $this->logger->info('Impossible to create subscription Data : ', ['exception message :' => $e->getMessage(), 'Data' => $insuranceData]);
+            for ($i = 0; $i < $orderItemQty; $i++) {
+                try {
+                    $subscriptionArray[] = new Subscription(
+                        $insuranceData['id'],
+                        $insuranceData['price'],
+                        $item->getSku(),
+                        Functions::priceToCents($orderItem->getOriginalPrice()),
+                        $subscriber,
+                        $this->getCallbackUrl()
+                    );
+                } catch (\Exception $e) {
+                    $this->logger->info('Impossible to create subscription Data : ', ['exception message :' => $e->getMessage(), 'Data' => $insuranceData]);
+                }
             }
+
 
         }
         return $subscriptionArray;
@@ -401,30 +405,33 @@ class InsuranceHelper extends AbstractHelper
             $dbSubscriptionData = [];
 
             /** @var \Alma\MonthlyPayments\Model\Insurance\Subscription $dbSubscription */
-            $dbSubscription = $this->subscriptionFactory->create();
             $orderItem = $item->getOrderItem();
+            $orderItemQty = (int)$item->getQty();
             $orderItemInsuranceData = json_decode($orderItem->getData(self::ALMA_INSURANCE_DB_KEY), true);
             $subscriptionResultContractData = [];
-            foreach ($subscriptionResult as $key => $result) {
-                if (array_search($orderItemInsuranceData['id'], $result)) {
-                    $subscriptionResultContractData = $result;
-                    unset($subscriptionResult[$key]);
-                    break;
+            for ($i = 0; $i < $orderItemQty; $i++) {
+                foreach ($subscriptionResult as $key => $result) {
+                    if (array_search($orderItemInsuranceData['id'], $result)) {
+                        $subscriptionResultContractData = $result;
+                        unset($subscriptionResult[$key]);
+                        break;
+                    }
                 }
+                $dbSubscription = $this->subscriptionFactory->create();
+                $dbSubscription->setOrderId($orderItem->getOrderId());
+                $dbSubscription->setOrderItemId($orderItem->getItemId());
+                $dbSubscription->setName($orderItemInsuranceData['name']);
+                $dbSubscription->setSubscriptionId($subscriptionResultContractData['id']);
+                $dbSubscription->setSubscriptionAmount(intval($subscriptionResultContractData['amount']));
+                $dbSubscription->setContractId($orderItemInsuranceData['id']);
+                $dbSubscription->setCmsReference($subscriptionResultContractData['cms_reference']);
+                $dbSubscription->setLinkedProductName($orderItemInsuranceData['parent_name']);
+                $dbSubscription->setLinkedProductPrice($orderItemInsuranceData['parent_price']);
+                $dbSubscription->setSubscriptionState($subscriptionResultContractData['state']);
+                $dbSubscription->setSubscriptionMode($mode);
+                $dbSubscription->setCallbackUrl($this->getCallbackUrl());
+                $dbSubscriptionArray[] = clone $dbSubscription;
             }
-            $dbSubscription->setOrderId($orderItem->getOrderId());
-            $dbSubscription->setOrderItemId($orderItem->getItemId());
-            $dbSubscription->setName($orderItemInsuranceData['name']);
-            $dbSubscription->setSubscriptionId($subscriptionResultContractData['id']);
-            $dbSubscription->setSubscriptionAmount(intval($subscriptionResultContractData['amount']));
-            $dbSubscription->setContractId($orderItemInsuranceData['id']);
-            $dbSubscription->setCmsReference($subscriptionResultContractData['cms_reference']);
-            $dbSubscription->setLinkedProductName($orderItemInsuranceData['parent_name']);
-            $dbSubscription->setLinkedProductPrice($orderItemInsuranceData['parent_price']);
-            $dbSubscription->setSubscriptionState($subscriptionResultContractData['state']);
-            $dbSubscription->setSubscriptionMode($mode);
-            $dbSubscription->setCallbackUrl($this->getCallbackUrl());
-            $dbSubscriptionArray[] = clone $dbSubscription;
         }
         return $dbSubscriptionArray;
     }

--- a/Observer/SalesOrderInvoicePayObserver.php
+++ b/Observer/SalesOrderInvoicePayObserver.php
@@ -40,11 +40,11 @@ class SalesOrderInvoicePayObserver implements ObserverInterface
     private InsuranceSendCustomerCartHelper $insuranceSendCustomerCartHelper;
 
     public function __construct(
-        Logger          $logger,
-        InsuranceHelper $insuranceHelper,
-        AlmaClient      $almaClient,
-        Subscription    $subscriptionResourceModel,
-        ApiConfigHelper $apiConfigHelper,
+        Logger                          $logger,
+        InsuranceHelper                 $insuranceHelper,
+        AlmaClient                      $almaClient,
+        Subscription                    $subscriptionResourceModel,
+        ApiConfigHelper                 $apiConfigHelper,
         InsuranceSendCustomerCartHelper $insuranceSendCustomerCartHelper
     ) {
         $this->logger = $logger;


### PR DESCRIPTION
### Reason for change

<!-- Describe here the reason for change, and provide a link to the corresponding ClickUp task or Sentry issue. -->

Buy product with insurance with qty 2 

[Linear task](https://linear.app/almapay/issue/ECOM-1441/fix-quantity-bug-for-subscription)

### Code changes

<!-- Describe here the code changes at a high level. Anything that can help reviewers review your PR. -->

### How to test

_As a reviewer, you are encouraged to test the PR locally._

<!-- Describe here how to test your changes, if applicable. Insert UI screenshots when relevant -->

### Checklist for authors and reviewers

<!-- Move to the next section the non applicable items -->

- [ ] The title of the PR uses business wording, not technical jargon, for the changelog readers to understand it
- [ ] The PR implements the changes asked in the referenced task / issue
- [ ] The automated tests are compliant with the [testing strategy](https://www.notion.so/almapay/Backend-testing-strategy-06c642cec1bf47b9b8feca3a91ea8d4a)
- [ ] The tests are relevant, and cover the corner/error cases, not only the happy path
- [ ] You understand the impact of this PR on existing code/features
- [ ] The changes include adequate logging and Datadog traces
- [ ] Documentation is updated (API, developer documentation, ADR, Notion...)

### Non applicable

<!-- Move here non applicable items of the checklist, if any -->
