### PR TITLE
Feature/ecom 1305 ac display a warning in order page & fix FR translation

### DIFF
--- a/Block/Adminhtml/Insurance/OrderViewMessage.php
+++ b/Block/Adminhtml/Insurance/OrderViewMessage.php
@@ -1,0 +1,59 @@
+<?php
+
+namespace Alma\MonthlyPayments\Block\Adminhtml\Insurance;
+
+use Alma\API\Entities\Insurance\Subscription;
+use Alma\MonthlyPayments\Helpers\InsuranceSubscriptionHelper;
+use Alma\MonthlyPayments\Helpers\Logger;
+use Magento\Backend\Block\Template;
+use Magento\Backend\Model\Url;
+use Magento\Directory\Helper\Data as DirectoryHelper;
+use Magento\Framework\Json\Helper\Data as JsonHelper;
+
+class OrderViewMessage extends Template
+{
+    private $logger;
+    private $insuranceSubscriptionHelper;
+    private $url;
+
+    public function __construct(
+        Logger $logger,
+        InsuranceSubscriptionHelper $insuranceSubscriptionHelper,
+        Template\Context $context,
+        Url $url,
+        array $data = [],
+        ?JsonHelper $jsonHelper = null,
+        ?DirectoryHelper $directoryHelper = null
+    ) {
+        parent::__construct(
+            $context,
+            $data,
+            $jsonHelper,
+            $directoryHelper
+        );
+        $this->logger = $logger;
+        $this->insuranceSubscriptionHelper = $insuranceSubscriptionHelper;
+        $this->url = $url;
+    }
+
+    public function hasActiveInsurance(): bool
+    {
+        $activeStatusArray = [
+            Subscription::STATE_STARTED,
+            Subscription::STATE_PENDING,
+            Subscription::STATE_PENDING_CANCELLATION
+        ];
+        $subscriptionCollection = $this->insuranceSubscriptionHelper->getCollectionSubscriptionsByOrderId((int)$this->getRequest()->getParam('order_id'));
+        foreach ($subscriptionCollection as $subscription) {
+            if (in_array($subscription['subscription_state'], $activeStatusArray)) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    public function getOrderDetailsLink(): string
+    {
+        return $this->url->getUrl('alma_monthly/insurance/subscriptiondetails', ['order_id' => $this->getRequest()->getParam('order_id')]);
+    }
+}

--- a/Block/Adminhtml/Insurance/SubscriptionDetails.php
+++ b/Block/Adminhtml/Insurance/SubscriptionDetails.php
@@ -98,15 +98,12 @@ class SubscriptionDetails extends Template
     public function getSubscriptionCollection(): array
     {
         $collection = $this->collectionFactory->create();
-        $this->logger->info('$collection', [$collection]);
-
         $collection->addFieldToFilter('order_id', $this->_request->getParam('order_id'));
         $collection->getSelect()->joinLeft(
             ['order' => 'sales_order'],
             'main_table.order_id = order.entity_id',
             ['order.increment_id']
         );
-        $this->logger->info('$collection->getData()', [$collection->getData()]);
         return $collection->getData();
     }
 

--- a/Helpers/InsuranceSubscriptionHelper.php
+++ b/Helpers/InsuranceSubscriptionHelper.php
@@ -37,4 +37,11 @@ class InsuranceSubscriptionHelper extends AbstractHelper
             throw new Exception(__('Subscription not found'));
         }
     }
+
+    public function getCollectionSubscriptionsByOrderId(int $orderId): array
+    {
+        $collection = $this->subscriptionCollection->create();
+        $collection->addFieldToFilter('order_id', $orderId);
+        return $collection->getData();
+    }
 }

--- a/Test/Unit/Block/Adminhtml/Insurance/OrderViewMessageTest.php
+++ b/Test/Unit/Block/Adminhtml/Insurance/OrderViewMessageTest.php
@@ -1,0 +1,157 @@
+<?php
+
+namespace Alma\MonthlyPayments\Test\Unit\Block\Adminhtml\Insurance;
+
+use Alma\MonthlyPayments\Block\Adminhtml\Insurance\OrderViewMessage;
+use Alma\MonthlyPayments\Helpers\InsuranceSubscriptionHelper;
+use Alma\MonthlyPayments\Helpers\Logger;
+use Magento\Backend\Block\Template\Context;
+use Magento\Backend\Model\Url;
+use PHPUnit\Framework\TestCase;
+
+class OrderViewMessageTest extends TestCase
+{
+
+    private $logger;
+    private $insuranceSubscriptionHelper;
+    private $context;
+    private $jsonHelper;
+    private $directoryHelper;
+    private $url;
+
+    protected function tearDown(): void
+    {
+        $this->logger = null;
+        $this->insuranceSubscriptionHelper = null;
+        $this->context = null;
+        $this->jsonHelper = null;
+        $this->directoryHelper = null;
+        $this->url = null;
+    }
+
+    protected function setUp(): void
+    {
+        $this->logger = $this->createMock(Logger::class);
+        $this->insuranceSubscriptionHelper = $this->createMock(InsuranceSubscriptionHelper::class);
+
+        $requestInterface = $this->createMock(\Magento\Framework\App\RequestInterface::class);
+        $requestInterface->method('getParam')->willReturn('42');
+        $this->context = $this->createMock(Context::class);
+        $this->context->method('getRequest')->willReturn($requestInterface);
+
+        $this->url = $this->createMock(Url::class);
+        $this->jsonHelper = $this->createMock(\Magento\Framework\Json\Helper\Data::class);
+        $this->directoryHelper = $this->createMock(\Magento\Directory\Helper\Data::class);
+    }
+
+    private function createOrderViewMessage(): OrderViewMessage
+    {
+        return new OrderViewMessage(
+            $this->logger,
+            $this->insuranceSubscriptionHelper,
+            $this->context,
+            $this->url,
+            [],
+            $this->jsonHelper,
+            $this->directoryHelper
+        );
+    }
+
+
+    /**
+     * Given request no subscription is found
+     * @return void
+     */
+    public function testShouldReturnFalseWhenNoSubscriptionIsFound(): void
+    {
+        $this->insuranceSubscriptionHelper->method('getCollectionSubscriptionsByOrderId')->willReturn([]);
+        $orderViewMessage = $this->createOrderViewMessage();
+        $this->assertFalse($orderViewMessage->hasActiveInsurance());
+    }
+
+
+
+
+    /**
+     * Given request subscription are found with "subscription_state" inactive
+     * @dataProvider inactiveStatusDataProvider
+     * @param $activeStatus
+     * @return void
+     */
+    public function testShouldReturnFalseWhenSubscriptionIsFoundWithAnInactiveStatus($inactiveStatus): void
+    {
+        $this->insuranceSubscriptionHelper->method('getCollectionSubscriptionsByOrderId')->willReturn([['entity_id' => 42, 'subscription_state' => $inactiveStatus]]);
+        $orderViewMessage = $this->createOrderViewMessage();
+        $this->assertFalse($orderViewMessage->hasActiveInsurance());
+    }
+
+    /**
+     * Given request subscription are found with "subscription_state" active
+     * @dataProvider activeStatusDataProvider
+     * @param $activeStatus
+     * @return void
+     */
+    public function testShouldReturnTrueWhenSubscriptionIsFoundWithAnActiveStatus($activeStatus): void
+    {
+        $this->insuranceSubscriptionHelper->method('getCollectionSubscriptionsByOrderId')->willReturn([['entity_id' => 42, 'subscription_state' => $activeStatus]]);
+        $orderViewMessage = $this->createOrderViewMessage();
+        $this->assertTrue($orderViewMessage->hasActiveInsurance());
+    }
+
+    /**
+     * Given request subscription are found with 2 subscription with at least on active "subscription_state"
+     * @dataProvider mixedStatusWithOneActiveDataProvider
+     * @return void
+     */
+    public function testShouldReturnTrueIfAtLeast1StateIsInActiveList($firstState, $secondState): void
+    {
+        $this->insuranceSubscriptionHelper->method('getCollectionSubscriptionsByOrderId')->willReturn([['entity_id' => 42, 'subscription_state' => $firstState], ['entity_id' => 43, 'subscription_state' => $secondState]]);
+        $orderViewMessage = $this->createOrderViewMessage();
+        $this->assertTrue($orderViewMessage->hasActiveInsurance());
+    }
+
+    /**
+     * Given request subscription are found with 2 subscription with all inactive "subscription_state"
+     * @return void
+     */
+    public function testShouldReturnFalseForAllInactiveSubscriptionState(): void
+    {
+        $this->insuranceSubscriptionHelper->method('getCollectionSubscriptionsByOrderId')->willReturn([['entity_id' => 42, 'subscription_state' => 'refunded'], ['entity_id' => 43, 'subscription_state' => 'canceled']]);
+        $orderViewMessage = $this->createOrderViewMessage();
+        $this->assertFalse($orderViewMessage->hasActiveInsurance());
+    }
+
+    private function activeStatusDataProvider(): array
+    {
+        return [
+            'Started' => ['started'],
+            'Pending Cancellation' => ['pending_cancellation'],
+            'Pending' => ['pending'],
+        ];
+    }
+
+    private function inactiveStatusDataProvider(): array
+    {
+        return [
+            'failed' => ['failed'],
+            'canceled' => ['canceled'],
+            'Refunded' => ['refunded'],
+        ];
+    }
+    private function mixedStatusWithOneActiveDataProvider(): array
+    {
+        return [
+            'started & failed' => ['started', 'failed'],
+            'failed & started' => ['failed', 'started'],
+            'Pending Cancellation & refunded' => ['pending_cancellation', 'refunded'],
+            'Canceled & pending' => ['canceled', 'pending'],
+        ];
+    }
+
+    public function testGetDetailUrlIsCalledWithGoodParams():void
+    {
+        $this->url->expects($this->once())->method('getUrl')->with('alma_monthly/insurance/subscriptiondetails', ['order_id' => '42'])->willReturn('https://mywebsite/alma_monthly/insurance/subscriptiondetails/order_id/42');
+        $this->createOrderViewMessage()->getOrderDetailsLink();
+    }
+
+}

--- a/i18n/en_US.csv
+++ b/i18n/en_US.csv
@@ -169,3 +169,5 @@
 "Refunded", "Refunded"
 "Include insurance","Include insurance"
 "Unknown","Unknown"
+"Remember to cancel insurance subscriptions before initiating a refund", "Remember to cancel insurance subscriptions before initiating a refund"
+"This order includes one or more insurance subscriptions. Make sure that the subscription(s) is canceled before proceeding with the refund. <a href =%s > Manage the cancellation directly here. </a>", "This order includes one or more insurance subscriptions. Make sure that the subscription(s) is canceled before proceeding with the refund. <a href =%s > Manage the cancellation directly here. </a>"

--- a/i18n/fr_FR.csv
+++ b/i18n/fr_FR.csv
@@ -155,7 +155,7 @@
 "Alma Insurance", "Alma Assurance"
 "Insurance configuration", "Configuration de l'assurance"
 "Subscription list", "Souscriptions"
-"Protected By Alma Insurance", "Protéger par Alma Assurance"
+"Protected By Alma Insurance", "Protégé par Alma Assurance"
 "Alma Subscription list", "Liste des Souscriptions Alma"
 "Alma Subscription details for Order", "Alma Subscription details for Order"
 "Increment Id", "Numéro de commande"

--- a/i18n/fr_FR.csv
+++ b/i18n/fr_FR.csv
@@ -169,3 +169,5 @@
 "Refunded", "Remboursement effectué"
 "Include insurance","Contient de l'assurance"
 "Unknown","Inconnu"
+"Remember to cancel insurance subscriptions before initiating a refund", "Pensez a bien résilier les souscriptions d’assurance avant de procéder un remboursement"
+"This order includes one or more insurance subscriptions. Make sure that the subscription(s) is canceled before proceeding with the refund. <a href =%s > Manage the cancellation directly here. </a>", "Cette commande comprend une ou plusieurs souscriptions à l'assurance. Assurez-vous que la ou les souscriptions sont résiliées avant de procéder au remboursement. <a href =%s > Gérez la résiliation directement ici. </a>"

--- a/view/adminhtml/layout/sales_order_view.xml
+++ b/view/adminhtml/layout/sales_order_view.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0"?>
+
+<page xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" layout="admin-2columns-left"
+      xsi:noNamespaceSchemaLocation="urn:magento:framework:View/Layout/etc/page_configuration.xsd">
+    <body>
+        <referenceContainer name="content">
+            <block before="-" class="Alma\MonthlyPayments\Block\Adminhtml\Insurance\OrderViewMessage" name="alma-insurance-order-view-message" template="Alma_MonthlyPayments::insurance/order-view-message.phtml">
+            </block>
+        </referenceContainer>
+    </body>
+</page>

--- a/view/adminhtml/templates/insurance/order-view-message.phtml
+++ b/view/adminhtml/templates/insurance/order-view-message.phtml
@@ -1,0 +1,13 @@
+<?php
+/**
+ * @var $block \Alma\MonthlyPayments\Block\Adminhtml\Insurance\OrderViewMessage
+ */
+
+?>
+<?php if ($block->hasActiveInsurance()): ?>
+    <div class="message message-warning warning">
+        <b><?= __('Remember to cancel insurance subscriptions before initiating a refund') ?></b> <br/>
+        <?= sprintf(__('This order includes one or more insurance subscriptions. Make sure that the subscription(s) is canceled before proceeding with the refund. <a href =%s > Manage the cancellation directly here. </a>'), $block->getOrderDetailsLink()) ?>
+    </div>
+<?php endif; ?>
+


### PR DESCRIPTION
### Reason for change

<!-- Describe here the reason for change, and provide a link to the corresponding ClickUp task or Sentry issue. -->

Add a message in sales order view page if a subscription is active for this order.

Also fix FR translation for "Protected by alma insurance" 

[Linear task](https://linear.app/almapay/issue/ECOM-1305/[🧩-ac]-display-a-warning-in-order-page)

### Code changes

<!-- Describe here the code changes at a high level. Anything that can help reviewers review your PR. -->

### How to test

_As a reviewer, you are encouraged to test the PR locally._

<!-- Describe here how to test your changes, if applicable. Insert UI screenshots when relevant -->

### Checklist for authors and reviewers

<!-- Move to the next section the non applicable items -->

- [ ] The title of the PR uses business wording, not technical jargon, for the changelog readers to understand it
- [ ] The PR implements the changes asked in the referenced task / issue
- [ ] The automated tests are compliant with the [testing strategy](https://www.notion.so/almapay/Backend-testing-strategy-06c642cec1bf47b9b8feca3a91ea8d4a)
- [ ] The tests are relevant, and cover the corner/error cases, not only the happy path
- [ ] You understand the impact of this PR on existing code/features
- [ ] The changes include adequate logging and Datadog traces
- [ ] Documentation is updated (API, developer documentation, ADR, Notion...)

### Non applicable

<!-- Move here non applicable items of the checklist, if any -->
