### PR TITLE
Disable widget configuration if feature flag is removed

### DIFF
--- a/Helpers/Availability.php
+++ b/Helpers/Availability.php
@@ -28,6 +28,7 @@ namespace Alma\MonthlyPayments\Helpers;
 use Alma\API\Entities\Merchant;
 use Alma\API\RequestError;
 use Alma\MonthlyPayments\Helpers\Exceptions\AlmaClientException;
+use Alma\MonthlyPayments\Model\Exceptions\AlmaInsuranceFlagException;
 use Magento\Store\Model\StoreManagerInterface;
 
 class Availability
@@ -103,6 +104,17 @@ class Availability
             $this->logger->error("Could not create API client to check API key", [$mode]);
             $this->logger->error("Exception message", [$e->getMessage()]);
             return false;
+        }
+    }
+
+    public function getMerchantInsuranceAvailability() :bool
+    {
+        try {
+            $merchant =$this->almaClient->getDefaultClient()->merchants->me();
+            return $merchant->cms_insurance ?? true;
+        } catch (AlmaClientException | RequestError $e) {
+            $this->logger->error("Exception message", [$e->getMessage()]);
+            throw new AlmaInsuranceFlagException($e->getMessage(), $this->logger, 0, $e);
         }
     }
 }

--- a/Helpers/ConfigHelper.php
+++ b/Helpers/ConfigHelper.php
@@ -231,8 +231,18 @@ class ConfigHelper extends AbstractHelper
                 $isAllowedInsurance = $merchant->cms_insurance ? 1 : 0;
             }
         }
-        $this->saveConfig(InsuranceHelper::IS_ALLOWED_INSURANCE_PATH, $isAllowedInsurance, $scope, $storeId);
+        $this->saveIsAllowedInsuranceValue($isAllowedInsurance, $scope, $storeId);
     }
+
+    public function saveIsAllowedInsuranceValue($value, $scope, $storeId):void
+    {
+        $this->saveConfig(InsuranceHelper::IS_ALLOWED_INSURANCE_PATH, $value, $scope, $storeId);
+    }
+    public function clearInsuranceConfig($scope, $storeId):void
+    {
+        $this->saveConfig(InsuranceHelper::ALMA_INSURANCE_CONFIG_CODE, null, $scope, $storeId);
+    }
+
 
     /**
      * @return FeePlan[]

--- a/Helpers/InsuranceHelper.php
+++ b/Helpers/InsuranceHelper.php
@@ -122,6 +122,7 @@ class InsuranceHelper extends AbstractHelper
         $this->storeManager = $storeManager;
     }
 
+
     /**
      * @return InsuranceConfig
      */

--- a/Model/Exceptions/AlmaInsuranceFlagException.php
+++ b/Model/Exceptions/AlmaInsuranceFlagException.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace Alma\MonthlyPayments\Model\Exceptions;
+
+use Exception;
+
+class AlmaInsuranceFlagException extends Exception
+{
+    public function __construct($message, $logger, $code = 0, \Throwable $previous = null)
+    {
+        parent::__construct($message, $code, $previous);
+        $logger->warning($message);
+        if (isset($previous)) {
+            $logger->warning(sprintf('Previous exception message : %s', $previous->getMessage()));
+        }
+    }
+}

--- a/Observer/Admin/LoadConfigObserver.php
+++ b/Observer/Admin/LoadConfigObserver.php
@@ -2,10 +2,17 @@
 
 namespace Alma\MonthlyPayments\Observer\Admin;
 
+use Alma\MonthlyPayments\Helpers\Availability;
+use Alma\MonthlyPayments\Helpers\ConfigHelper;
+use Alma\MonthlyPayments\Helpers\InsuranceHelper;
+use Alma\MonthlyPayments\Helpers\Logger;
 use Alma\MonthlyPayments\Helpers\PaymentPlansHelper;
+use Alma\MonthlyPayments\Helpers\StoreHelper;
+use Alma\MonthlyPayments\Model\Exceptions\AlmaInsuranceFlagException;
 use Magento\Backend\Model\UrlInterface;
 use Magento\Framework\Event\Observer;
 use Magento\Framework\Event\ObserverInterface;
+use Magento\Store\Model\StoreManager;
 
 class LoadConfigObserver implements ObserverInterface
 {
@@ -17,23 +24,53 @@ class LoadConfigObserver implements ObserverInterface
      * @var PaymentPlansHelper
      */
     private $paymentPlansHelper;
+    private $logger;
+    private $availability;
+    private $configHelper;
+    private $storeHelper;
 
     public function __construct(
-        UrlInterface $url,
-        PaymentPlansHelper $paymentPlansHelper
-    ) {
+        Logger             $logger,
+        UrlInterface       $url,
+        PaymentPlansHelper $paymentPlansHelper,
+        Availability       $availability,
+        ConfigHelper       $configHelper,
+        StoreHelper        $storeHelper
+    )
+    {
         $this->url = $url;
         $this->paymentPlansHelper = $paymentPlansHelper;
+        $this->logger = $logger;
+        $this->availability = $availability;
+        $this->configHelper = $configHelper;
+        $this->storeHelper = $storeHelper;
     }
 
     /**
      * @param Observer $observer
      * @return void
+     * @throws AlmaInsuranceFlagException
      */
     public function execute(Observer $observer): void
     {
-        if (preg_match('!section\/payment!', $this->url->getCurrentUrl())) {
-            $this->paymentPlansHelper->saveBaseApiPlansConfig();
+        if (preg_match('!section\/(alma_insurance_section|payment)!', $this->url->getCurrentUrl(), $matches)) {
+            $cmsInsuranceFlagValue = $this->availability->getMerchantInsuranceAvailability();
+            if(!$cmsInsuranceFlagValue && $this->configHelper->getConfigByCode(InsuranceHelper::IS_ALLOWED_INSURANCE_PATH) === '1'){
+                // Hide immediately the insurance section if the merchant is not allowed to use it
+                $this->configHelper->saveIsAllowedInsuranceValue(
+                    0,
+                    $this->storeHelper->getScope(),
+                    $this->storeHelper->getStoreId()
+                );
+                $this->configHelper->clearInsuranceConfig(
+                    $this->storeHelper->getScope(),
+                    $this->storeHelper->getStoreId()
+                );
+                //TODO REDIRECT TO CURRENT PAGE FOR RELOAD PAGE WITHOUT CONFIG ENABLED
+            }
+            if ($matches[1] === 'payment') {
+                $this->paymentPlansHelper->saveBaseApiPlansConfig();
+            }
         }
     }
 }

--- a/Test/Unit/Helpers/AvailabilityTest.php
+++ b/Test/Unit/Helpers/AvailabilityTest.php
@@ -1,0 +1,109 @@
+<?php
+
+namespace Alma\MonthlyPayments\Test\Unit\Helpers;
+
+use Alma\API\Client;
+use Alma\API\Endpoints\Merchants;
+use Alma\API\Entities\Merchant;
+use Alma\API\RequestError;
+use Alma\MonthlyPayments\Helpers\AlmaClient;
+use Alma\MonthlyPayments\Helpers\ApiConfigHelper;
+use Alma\MonthlyPayments\Helpers\Availability;
+use Alma\MonthlyPayments\Helpers\Logger;
+use Alma\MonthlyPayments\Model\Exceptions\AlmaInsuranceFlagException;
+use Magento\Store\Model\StoreManagerInterface;
+use PHPUnit\Framework\TestCase;
+
+class AvailabilityTest extends TestCase
+{
+    private $storeManager;
+    private $almaClient;
+    private $logger;
+    private $apiConfigHelper;
+    private $merchantsEndpoint;
+
+    protected function setUp(): void
+    {
+        $clientMock = $this->createMock(Client::class);
+        $this->merchantsEndpoint = $this->createMock(Merchants::class);
+        $clientMock->merchants = $this->merchantsEndpoint;
+        $this->storeManager = $this->createMock(StoreManagerInterface::class);
+        $this->almaClient = $this->createMock(AlmaClient::class);
+        $this->almaClient->method('getDefaultClient')->willReturn($clientMock);
+        $this->apiConfigHelper = $this->createMock(ApiConfigHelper::class);
+        $this->logger = $this->createMock(Logger::class);
+    }
+
+    protected function tearDown(): void
+    {
+        $this->storeManager = null;
+        $this->almaClient = null;
+        $this->apiConfigHelper = null;
+        $this->logger = null;
+        $this->merchantsEndpoint = null;
+    }
+
+    private function createAvailability(): Availability
+    {
+        return new Availability(
+            $this->storeManager,
+            $this->almaClient,
+            $this->apiConfigHelper,
+            $this->logger
+        );
+    }
+
+    public function testThrowAlmaInsuranceFlagExceptionIfMeThrowException():void
+    {
+        $this->merchantsEndpoint->method('me')->willThrowException(new RequestError('error'));
+        $this->expectException(AlmaInsuranceFlagException::class);
+        $this->createAvailability()->getMerchantInsuranceAvailability();
+    }
+
+    public function testGivenNoCmsInsuranceFlagInMeReturnTrue(): void
+    {
+        $meData = $this->extendedDataMe();
+        $meData->cms_insurance = null;
+        $this->merchantsEndpoint->method('me')->willReturn($meData);
+        $this->assertTrue($this->createAvailability()->getMerchantInsuranceAvailability());
+    }
+
+    /**
+     * @dataProvider extendedDataMeDataProvider
+     * @param $flagValue
+     * @return void
+     * @throws AlmaInsuranceFlagException
+     */
+    public function testGivenCmsInsuranceFlagInMeReturnFlagValue($meData, $result):void
+    {
+
+        $this->merchantsEndpoint->method('me')->willReturn($meData);
+        $this->assertEquals($result, $this->createAvailability()->getMerchantInsuranceAvailability());
+    }
+
+
+    public function extendedDataMe($cms_insurance = true)
+    {
+        return new Merchant([
+            'id' => 'merchant_11mLCKp39by3Yb1VAAIAWWqSwYg8Q2Fy17',
+            'name' => 'Alma',
+            'country' => 'FR',
+            'cms_insurance' => $cms_insurance,
+        ]);
+    }
+
+    public function extendedDataMeDataProvider()
+    {
+        return [
+            'flag insurance true' => [
+                'flag' => $this->extendedDataMe(true),
+                'result' => true
+            ],
+            'flag insurance false' => [
+                'flag' => $this->extendedDataMe(false),
+                'result' => false
+            ]
+        ];
+    }
+
+}

--- a/Test/Unit/Helpers/ConfigHelperTest.php
+++ b/Test/Unit/Helpers/ConfigHelperTest.php
@@ -94,6 +94,41 @@ class ConfigHelperTest extends TestCase
         $this->createConfigHelper()->saveIsAllowedInsurance(null, 0, 1);
     }
 
+    public function testSaveIsAllowedInsuranceValue0()
+    {
+        $this->writerInterface->expects($this->once())->method('save')->with(
+            ConfigHelper::XML_PATH_PAYMENT . '/' . ConfigHelper::XML_PATH_METHODE . '/'.InsuranceHelper::IS_ALLOWED_INSURANCE_PATH ,
+            0,
+            0,
+            1
+        );
+        $this->createConfigHelper()->saveIsAllowedInsuranceValue(0, 0, 1);
+    }
+
+    public function testSaveIsAllowedInsuranceValue1()
+    {
+        $this->writerInterface->expects($this->once())->method('save')->with(
+            ConfigHelper::XML_PATH_PAYMENT . '/' . ConfigHelper::XML_PATH_METHODE . '/'.InsuranceHelper::IS_ALLOWED_INSURANCE_PATH ,
+            1,
+            0,
+            1
+        );
+        $this->createConfigHelper()->saveIsAllowedInsuranceValue(1, 0, 1);
+    }
+
+    public function testClearInsuranceConfig():void
+    {
+        $this->writerInterface->expects($this->once())
+            ->method('save')
+            ->with(
+            ConfigHelper::XML_PATH_PAYMENT . '/' . ConfigHelper::XML_PATH_METHODE . '/'.InsuranceHelper::ALMA_INSURANCE_CONFIG_CODE ,
+            null,
+            0,
+            1
+        );
+        $this->createConfigHelper()->clearInsuranceConfig(0, 1);
+    }
+
 
     private function createConfigHelper(): ConfigHelper
     {

--- a/Test/Unit/Observer/Admin/LoadConfigObserverTest.php
+++ b/Test/Unit/Observer/Admin/LoadConfigObserverTest.php
@@ -1,0 +1,169 @@
+<?php
+
+namespace Alma\MonthlyPayments\Test\Unit\Observer\Admin;
+
+use Alma\MonthlyPayments\Helpers\Availability;
+use Alma\MonthlyPayments\Helpers\ConfigHelper;
+use Alma\MonthlyPayments\Helpers\Logger;
+use Alma\MonthlyPayments\Helpers\PaymentPlansHelper;
+use Alma\MonthlyPayments\Helpers\StoreHelper;
+use Alma\MonthlyPayments\Observer\Admin\LoadConfigObserver;
+use Magento\Backend\Model\UrlInterface;
+use Magento\Framework\Event\Observer;
+use PHPUnit\Framework\TestCase;
+
+class LoadConfigObserverTest extends TestCase
+{
+    const INSURANCE_URL = 'https://mytestSite.test/backadm/admin/system_config/edit/section/alma_insurance_section/key/ee6/';
+    const PAYMENT_URL = 'https://mytestSite.test/backadm/admin/system_config/edit/section/payment/key/ee6/';
+    const NON_PAYMENT_URL = 'https://mytestSite.test/backadm/admin/system_config/edit/section/catalog/key/ee6/';
+    private $urlInterface;
+    private $paymentPlansHelper;
+    private $logger;
+    private $observer;
+    private $availability;
+    private $configHelper;
+    private $storeHelper;
+
+    public function setUp(): void
+    {
+        $this->logger = $this->createMock(Logger::class);
+        $this->urlInterface = $this->createMock(UrlInterface::class);
+        $this->paymentPlansHelper = $this->createMock(PaymentPlansHelper::class);
+        $this->observer = $this->createMock(Observer::class);
+        $this->availability = $this->createMock(Availability::class);
+        $this->configHelper = $this->createMock(ConfigHelper::class);
+        $this->storeHelper = $this->createMock(StoreHelper::class);
+        $this->storeHelper->method('getScope')->willReturn('default');
+        $this->storeHelper->method('getStoreId')->willReturn('1');
+    }
+
+    public function tearDown(): void
+    {
+        $this->logger = null;
+        $this->urlInterface = null;
+        $this->paymentPlansHelper = null;
+        $this->availability = null;
+        $this->configHelper = null;
+        $this->storeHelper = null;
+    }
+
+    private function createLoadConfigObserver(): LoadConfigObserver
+    {
+        return new LoadConfigObserver(
+            $this->logger,
+            $this->urlInterface,
+            $this->paymentPlansHelper,
+            $this->availability,
+            $this->configHelper,
+            $this->storeHelper
+        );
+    }
+
+    public function testNeverCallSaveBaseApiPlansConfigForNonPaymentUrl(): void
+    {
+        $this->urlInterface->expects($this->once())
+            ->method('getCurrentUrl')
+            ->willReturn(self::NON_PAYMENT_URL);
+
+        $this->paymentPlansHelper->expects($this->never())
+            ->method('saveBaseApiPlansConfig');
+        $this->createLoadConfigObserver()->execute($this->observer);
+    }
+
+    public function testCallSaveBaseApiPlansConfigForPaymentUrl(): void
+    {
+        $this->urlInterface->expects($this->once())
+            ->method('getCurrentUrl')
+            ->willReturn(self::PAYMENT_URL);
+
+        $this->paymentPlansHelper->expects($this->once())
+            ->method('saveBaseApiPlansConfig');
+        $this->createLoadConfigObserver()->execute($this->observer);
+    }
+
+    public function testNeverCallGetMerchantInsuranceAvailableForNonPaymentUrl(): void
+    {
+        $this->urlInterface->expects($this->once())
+            ->method('getCurrentUrl')
+            ->willReturn(self::NON_PAYMENT_URL);
+
+        $this->configHelper->expects($this->never())
+            ->method('saveIsAllowedInsuranceValue');
+
+        $this->configHelper->expects($this->never())
+            ->method('clearInsuranceConfig');
+        $this->availability->expects($this->never())
+            ->method('getMerchantInsuranceAvailability');
+        $this->createLoadConfigObserver()->execute($this->observer);
+    }
+
+    public function testCallGetMerchantInsuranceAvailabilityHasFalseAndGetConfigCodeTrueForPaymentUrl(): void
+    {
+        $this->urlInterface->expects($this->once())
+            ->method('getCurrentUrl')
+            ->willReturn(self::PAYMENT_URL);
+
+        $this->availability->expects($this->once())
+            ->method('getMerchantInsuranceAvailability')
+            ->willReturn(false);
+        $this->configHelper->expects($this->once())
+            ->method('getConfigByCode')
+            ->willReturn('1');
+        $this->configHelper->expects($this->once())
+            ->method('saveIsAllowedInsuranceValue')
+            ->with(0);
+        $this->configHelper->expects($this->once())
+            ->method('clearInsuranceConfig');
+        $this->createLoadConfigObserver()->execute($this->observer);
+    }
+
+    public function testCallGetMerchantInsuranceAvailabilityHasFalseAndGetConfigCodeFalseForPaymentUrl(): void
+    {
+        $this->urlInterface->expects($this->once())
+            ->method('getCurrentUrl')
+            ->willReturn(self::PAYMENT_URL);
+
+        $this->availability->expects($this->once())
+            ->method('getMerchantInsuranceAvailability')
+            ->willReturn(false);
+        $this->configHelper->expects($this->once())
+            ->method('getConfigByCode')
+            ->willReturn('0');
+        $this->configHelper->expects($this->never())
+            ->method('saveIsAllowedInsuranceValue');
+        $this->configHelper->expects($this->never())
+            ->method('clearInsuranceConfig');
+        $this->createLoadConfigObserver()->execute($this->observer);
+    }
+
+    public function testCallGetMerchantInsuranceAvailabilityHasTrueForPaymentUrl(): void
+    {
+        $this->urlInterface->expects($this->once())
+            ->method('getCurrentUrl')
+            ->willReturn(self::PAYMENT_URL);
+
+        $this->availability->expects($this->once())
+            ->method('getMerchantInsuranceAvailability')
+            ->willReturn(true);
+        $this->configHelper->expects($this->never())
+            ->method('getConfigByCode');
+        $this->configHelper->expects($this->never())
+            ->method('saveIsAllowedInsuranceValue');
+        $this->createLoadConfigObserver()->execute($this->observer);
+    }
+
+    public function testCallGetMerchantInsuranceAvailabilityAndNeverSaveBaseApiPlansConfigForInsuranceUrl(): void
+    {
+        $this->urlInterface->expects($this->once())
+            ->method('getCurrentUrl')
+            ->willReturn(self::INSURANCE_URL);
+
+        $this->availability->expects($this->once())
+            ->method('getMerchantInsuranceAvailability');
+
+        $this->paymentPlansHelper->expects($this->never())
+            ->method('saveBaseApiPlansConfig');
+        $this->createLoadConfigObserver()->execute($this->observer);
+    }
+}


### PR DESCRIPTION
### Reason for change

<!-- Describe here the reason for change, and provide a link to the corresponding ClickUp task or Sentry issue. -->

[Linear task](https://linear.app/almapay/issue/ECOM-1523/[🧩-ac]-disable-widget-configuration-if-feature-flag-is-removed)

### Code changes

As a merchant who already have the insurance feature
When the feature flag is removed
Then the "activate insurance" configuration should be false

The widget should not be visible from product page

The modal should ne be opened on "Add to cart" click

### How to test

Add flag insurance in the account Alma
Install module with insurance config
Remove the flag insurance in the account Alma
Check all the feature insurance is disabled in the shop

### Checklist for authors and reviewers

<!-- Move to the next section the non applicable items -->

- [ ] The title of the PR uses business wording, not technical jargon, for the changelog readers to understand it
- [ ] The PR implements the changes asked in the referenced task / issue
- [ ] The automated tests are compliant with the [testing strategy](https://www.notion.so/almapay/Backend-testing-strategy-06c642cec1bf47b9b8feca3a91ea8d4a)
- [ ] The tests are relevant, and cover the corner/error cases, not only the happy path
- [ ] You understand the impact of this PR on existing code/features
- [ ] The changes include adequate logging and Datadog traces
- [ ] Documentation is updated (API, developer documentation, ADR, Notion...)

### Non applicable

<!-- Move here non applicable items of the checklist, if any -->
