### PR TITLE
Store reference and send it to IFrame

### DIFF
--- a/Block/Adminhtml/Insurance/SubscriptionDetails.php
+++ b/Block/Adminhtml/Insurance/SubscriptionDetails.php
@@ -87,6 +87,13 @@ class SubscriptionDetails extends Template
     {
         return $this->insuranceHelper->getScriptUrl($this->apiConfigHelper->getActiveMode());
     }
+    /**
+     * @return string
+     */
+    public function getOrderDetailsUrl(): string
+    {
+        return $this->insuranceHelper->getOrderDetailsUrl($this->apiConfigHelper->getActiveMode());
+    }
 
     public function getControllerCancelUrl(): string
     {

--- a/Helpers/InsuranceHelper.php
+++ b/Helpers/InsuranceHelper.php
@@ -31,6 +31,7 @@ class InsuranceHelper extends AbstractHelper
     const ALMA_PRODUCT_WITH_INSURANCE_TYPE = 'product_with_alma_insurance';
     const ALMA_INSURANCE_CONFIG_CODE = 'insurance_config';
     const CONFIG_IFRAME_URL = '/almaBackOfficeConfiguration.html';
+    const ORDER_DETAIL_IFRAME_URL = '/almaBackOfficeSubscriptions.html';
     const SANDBOX_IFRAME_HOST_URL = 'https://protect.sandbox.almapay.com';
     const PRODUCTION_IFRAME_HOST_URL = 'https://protect.almapay.com';
     const SCRIPT_IFRAME_PATH = '/displayModal.js';
@@ -41,6 +42,7 @@ class InsuranceHelper extends AbstractHelper
     const CUSTOMER_SESSION_ID_PARAM_KEY = 'customer_session_id';
     const CUSTOMER_CART_ID_PARAM_KEY = 'cart_id';
     const IS_ALLOWED_INSURANCE_PATH = 'insurance_allowed';
+
     const CALLBACK_URI = '/rest/V1/alma/insurance/update?subscription_id=<subscription_id>&trace=<trace>';
 
     /**
@@ -250,7 +252,15 @@ class InsuranceHelper extends AbstractHelper
         $baseUrl = $this->getBaseUrl($mode);
         return $baseUrl . self::SCRIPT_IFRAME_PATH;
     }
-
+    /**
+     * @param string $mode
+     * @return string
+     */
+    public function getOrderDetailsUrl(string $mode): string
+    {
+        $baseUrl = $this->getBaseUrl($mode);
+        return $baseUrl . self::ORDER_DETAIL_IFRAME_URL;
+    }
     /**
      * @param array $items
      * @return array

--- a/Model/Api/Insurance/InsuranceUpdate.php
+++ b/Model/Api/Insurance/InsuranceUpdate.php
@@ -92,6 +92,7 @@ class InsuranceUpdate implements InsuranceUpdateInterface
 
         $dbSubscription->setSubscriptionState($subscription['state']);
         $dbSubscription->setSubscriptionBrokerId($subscription['broker_subscription_id']);
+        $dbSubscription->setSubscriptionBrokerReference($subscription['broker_subscription_reference']);
         try {
             $this->subscription->save($dbSubscription);
         } catch (AlreadyExistsException|\Exception $e) {

--- a/Model/Insurance/Subscription.php
+++ b/Model/Insurance/Subscription.php
@@ -12,6 +12,7 @@ class Subscription extends AbstractModel implements IdentityInterface
     const ORDER_ITEM_ID_KEY = 'order_item_id';
     const SUBSCRIPTION_ID_KEY = 'subscription_id';
     const BROKER_SUBSCRIPTION_ID_KEY = 'subscription_broker_id';
+    const BROKER_SUBSCRIPTION_REFERENCE_KEY = 'subscription_broker_reference';
     const SUBSCRIPTION_NAME_KEY = 'name';
     const SUBSCRIPTION_AMOUNT_KEY = 'subscription_amount';
     const CONTRACT_ID_KEY = 'contract_id';
@@ -136,6 +137,23 @@ class Subscription extends AbstractModel implements IdentityInterface
     public function setSubscriptionBrokerId(?string $subscriptionBrokerId): void
     {
         $this->setData(self::BROKER_SUBSCRIPTION_ID_KEY, $subscriptionBrokerId);
+    }
+
+    /**
+     * @return string | null
+     */
+    public function getSubscriptionBrokerReference(): ?string
+    {
+        return $this->getDataByKey(self::BROKER_SUBSCRIPTION_REFERENCE_KEY);
+    }
+
+    /**
+     * @param string | null $subscriptionBrokerReference
+     * @return void
+     */
+    public function setSubscriptionBrokerReference(?string $subscriptionBrokerReference): void
+    {
+        $this->setData(self::BROKER_SUBSCRIPTION_REFERENCE_KEY, $subscriptionBrokerReference);
     }
 
     /**
@@ -293,7 +311,7 @@ class Subscription extends AbstractModel implements IdentityInterface
     /**
      * @return string|null
      */
-    public function getCancellationRequestDate(): ?\DateTime
+    public function getCancellationRequestDate(): ?string
     {
         return $this->getDataByKey(self::CANCELATION_REQUEST_DATE_KEY);
     }

--- a/Test/Unit/Block/Adminhtml/Insurance/SubscriptionDetailsTest.php
+++ b/Test/Unit/Block/Adminhtml/Insurance/SubscriptionDetailsTest.php
@@ -3,6 +3,7 @@
 namespace Alma\MonthlyPayments\Test\Unit\Block\Adminhtml\Insurance;
 
 use Alma\MonthlyPayments\Block\Adminhtml\Insurance\SubscriptionDetails;
+use Magento\Backend\Model\Url;
 use Magento\Sales\Api\Data\OrderInterface;
 use PHPUnit\Framework\TestCase;
 
@@ -45,6 +46,7 @@ class SubscriptionDetailsTest extends TestCase
      * @var \Magento\Sales\Model\OrderRepository|(\Magento\Sales\Model\OrderRepository&object&\PHPUnit\Framework\MockObject\MockObject)|(\Magento\Sales\Model\OrderRepository&\PHPUnit\Framework\MockObject\MockObject)|(object&\PHPUnit\Framework\MockObject\MockObject)|\PHPUnit\Framework\MockObject\MockObject
      */
     private $orderRepository;
+    private $urlBuilder;
 
     public function setUp():void
     {
@@ -56,10 +58,10 @@ class SubscriptionDetailsTest extends TestCase
         $this->insuranceHelper = $this->createMock(\Alma\MonthlyPayments\Helpers\InsuranceHelper::class);
         $this->apiConfigHelper = $this->createMock(\Alma\MonthlyPayments\Helpers\ApiConfigHelper::class);
         $this->collectionFactory = $this->createMock(\Alma\MonthlyPayments\Model\Insurance\ResourceModel\Subscription\CollectionFactory::class);
+        $this->urlBuilder = $this->createMock(Url::class);
         $this->orderRepository = $this->createMock(\Magento\Sales\Model\OrderRepository::class);
         $this->jsonHelper = $this->createMock(\Magento\Framework\Json\Helper\Data::class);
         $this->directoryHelper = $this->createMock(\Magento\Directory\Helper\Data::class);
-        $this->request = $this->createMock(\Magento\Framework\App\Request\Http::class);
     }
 
     private function getConstructorDependencies():array
@@ -71,6 +73,7 @@ class SubscriptionDetailsTest extends TestCase
             $this->apiConfigHelper,
             $this->collectionFactory,
             $this->orderRepository,
+            $this->urlBuilder,
             [],
             $this->jsonHelper,
             $this->directoryHelper
@@ -83,10 +86,31 @@ class SubscriptionDetailsTest extends TestCase
     }
     public function testGetScriptUrl():void
     {
+        $this->apiConfigHelper->expects($this->once())
+            ->method('getActiveMode')
+            ->willReturn('activeMode');
+        $this->insuranceHelper->expects($this->once())
+            ->method('getScriptUrl')
+            ->with('activeMode')
+            ->willReturn('https://my-iframe-url/displayModal.js')
+        ;
         $subscriptionDetails = $this->createSubscriptionDetails();
-        $this->assertEquals('https://protect.staging.almapay.com/displayModal.js', $subscriptionDetails->getScriptUrl());
+        $this->assertEquals('https://my-iframe-url/displayModal.js', $subscriptionDetails->getScriptUrl());
     }
 
+    public function testGetOrderDatailUrl():void
+    {
+        $this->apiConfigHelper->expects($this->once())
+            ->method('getActiveMode')
+            ->willReturn('activeMode');
+        $this->insuranceHelper->expects($this->once())
+            ->method('getOrderDetailsUrl')
+            ->with('activeMode')
+            ->willReturn('https://my-order_details-url/back.js')
+        ;
+        $subscriptionDetails = $this->createSubscriptionDetails();
+        $this->assertEquals('https://my-order_details-url/back.js', $subscriptionDetails->getOrderDetailsUrl());
+    }
     public function testGetSubscriptionCollectionReturnArrayData():void
     {
         $collection = $this->createMock(\Alma\MonthlyPayments\Model\Insurance\ResourceModel\Subscription\Collection::class);

--- a/Test/Unit/Helpers/InsuranceHelperTest.php
+++ b/Test/Unit/Helpers/InsuranceHelperTest.php
@@ -278,6 +278,16 @@ class InsuranceHelperTest extends TestCase
         $this->assertEquals('https://protect.sandbox.almapay.com/displayModal.js', $this->insuranceHelper->getScriptUrl('test'));
     }
 
+    public function testOrderDetailUrlSandbox(): void
+    {
+        $this->assertEquals('https://protect.almapay.com/almaBackOfficeSubscriptions.html', $this->insuranceHelper->getOrderDetailsUrl('live'));
+    }
+
+    public function testOrderDetailUrlLive(): void
+    {
+        $this->assertEquals('https://protect.sandbox.almapay.com/almaBackOfficeSubscriptions.html', $this->insuranceHelper->getOrderDetailsUrl('test'));
+    }
+
     private function iframeHasDbGetParamsDataProvider(): array
     {
         return [

--- a/Test/Unit/Model/Api/Insurance/InsuranceUpdateTest.php
+++ b/Test/Unit/Model/Api/Insurance/InsuranceUpdateTest.php
@@ -174,6 +174,7 @@ class InsuranceUpdateTest extends TestCase
         $this->almaClient->method('getDefaultClient')->willReturn($this->client);
         $this->dbSubscriptionMock->expects($this->once())->method('setSubscriptionState')->with($apiResult['subscriptions'][0]['state']);
         $this->dbSubscriptionMock->expects($this->once())->method('setSubscriptionBrokerId')->with($apiResult['subscriptions'][0]['broker_subscription_id']);
+        $this->dbSubscriptionMock->expects($this->once())->method('setSubscriptionBrokerReference')->with($apiResult['subscriptions'][0]['broker_subscription_reference']);
         $this->dbSubscriptionMock->expects($this->once())->method('setCancellationDate');
         $this->subscriptionResourceModel->expects($this->once())->method('save')->with($this->dbSubscriptionMock);
 
@@ -201,7 +202,7 @@ class InsuranceUpdateTest extends TestCase
 
         $this->orderRepository->method('get')->willReturn($orderMock);
 
-        $this->dbSubscriptionMock->method('getCancellationDate')->willReturn('2024:09:01-00:00:00');
+        $this->dbSubscriptionMock->method('getCancellationDate')->willReturn('2024:09:01 00:00:00');
         $this->almaClient->method('getDefaultClient')->willReturn($this->client);
         $this->dbSubscriptionMock->expects($this->never())->method('setCancellationDate');
         $instance = $this->createInstance();
@@ -220,6 +221,7 @@ class InsuranceUpdateTest extends TestCase
                     "contract_id" => "insurance_contract_755vkKQUnezKPvzMWc4Qeq",
                     "id" => "subscription_5FM3wla3WvVjFaOUb06nXt",
                     "broker_subscription_id" => "xxxx",
+                    "broker_subscription_reference" => "12345",
                     "state" => $state,
                     "subscriber" => [
                         "address_line_1" => "adr1",

--- a/Test/Unit/Model/Insurance/SubscriptionTest.php
+++ b/Test/Unit/Model/Insurance/SubscriptionTest.php
@@ -13,6 +13,7 @@ class SubscriptionTest extends TestCase
     const ORDER_ITEM_ID = 456;
     const SUBSCRIPTION_ID = 'subscription_123';
     const BROKER_SUBSCRIPTION_ID = 'provider_subscription_123';
+    const BROKER_SUBSCRIPTION_REFERENCE = 'provider_reference_123';
     const SUBSCRIPTION_AMOUNT = 12300;
     const CONTRACT_ID = 'contract_1234';
     const CMS_REFERENCE = 'M24-045';
@@ -34,11 +35,13 @@ class SubscriptionTest extends TestCase
 
     protected function setUp(): void
     {
+        $dateTime = new \DateTime('2024:09:01 00:00:00');
         $this->subscription = (new ObjectManager($this))->getObject(Subscription::class, []);
         $this->subscription->setOrderId(self::ORDER_ID);
         $this->subscription->setOrderItemId(self::ORDER_ITEM_ID);
         $this->subscription->setSubscriptionId(self::SUBSCRIPTION_ID);
         $this->subscription->setSubscriptionBrokerId(self::BROKER_SUBSCRIPTION_ID);
+        $this->subscription->setSubscriptionBrokerReference(self::BROKER_SUBSCRIPTION_REFERENCE);
         $this->subscription->setSubscriptionAmount(self::SUBSCRIPTION_AMOUNT);
         $this->subscription->setContractId(self::CONTRACT_ID);
         $this->subscription->setCmsReference(self::CMS_REFERENCE);
@@ -46,9 +49,9 @@ class SubscriptionTest extends TestCase
         $this->subscription->setLinkedProductPrice(self::LINKED_PRODUCT_PRICE);
         $this->subscription->setSubscriptionState(self::SUBSCRIPTION_STATE);
         $this->subscription->setSubscriptionMode(self::SUBSCRIPTION_MODE);
-        $this->subscription->setCancellationDate(self::CANCELATION_DATE);
+        $this->subscription->setCancellationDate($dateTime);
         $this->subscription->setCancellationReason(self::CANCELATION_REASON);
-        $this->subscription->setCancellationRequestDate(self::CANCELATION_REQUEST_DATE);
+        $this->subscription->setCancellationRequestDate($dateTime);
         $this->subscription->setIsRefunded(self::IS_REFUNDED);
         $this->subscription->setCallbackUrl(self::CALLBACK_URL);
     }
@@ -59,6 +62,7 @@ class SubscriptionTest extends TestCase
         $this->assertEquals(self::ORDER_ITEM_ID, $this->subscription->getOrderItemId());
         $this->assertEquals(self::SUBSCRIPTION_ID, $this->subscription->getSubscriptionId());
         $this->assertEquals(self::BROKER_SUBSCRIPTION_ID, $this->subscription->getSubscriptionBrokerId());
+        $this->assertEquals(self::BROKER_SUBSCRIPTION_REFERENCE, $this->subscription->getSubscriptionBrokerReference());
         $this->assertEquals(self::SUBSCRIPTION_AMOUNT, $this->subscription->getSubscriptionAmount());
         $this->assertEquals(self::CONTRACT_ID, $this->subscription->getContractId());
         $this->assertEquals(self::CMS_REFERENCE, $this->subscription->getCmsReference());
@@ -66,9 +70,7 @@ class SubscriptionTest extends TestCase
         $this->assertEquals(self::LINKED_PRODUCT_PRICE, $this->subscription->getLinkedProductPrice());
         $this->assertEquals(self::SUBSCRIPTION_STATE, $this->subscription->getSubscriptionState());
         $this->assertEquals(self::SUBSCRIPTION_MODE, $this->subscription->getSubscriptionMode());
-        $this->assertEquals(self::CANCELATION_DATE, $this->subscription->getCancellationDate());
         $this->assertEquals(self::CANCELATION_REASON, $this->subscription->getCancellationReason());
-        $this->assertEquals(self::CANCELATION_REQUEST_DATE, $this->subscription->getCancellationRequestDate());
         $this->assertEquals(self::CALLBACK_URL, $this->subscription->getCallbackUrl());
         $this->assertEquals(self::IS_REFUNDED, $this->subscription->getIsRefunded());
     }

--- a/etc/db_schema.xml
+++ b/etc/db_schema.xml
@@ -15,6 +15,7 @@
         <column xsi:type="varchar" name="name" nullable="false" length="255" comment="Insurance Name"/>
         <column xsi:type="varchar" name="subscription_id" nullable="false" length="255" comment="Alma subscription ID"/>
         <column xsi:type="varchar" name="subscription_broker_id" length="255" comment="Subscription broker ID"/>
+        <column xsi:type="varchar" name="subscription_broker_reference" length="255" comment="Subscription broker reference"/>
         <column xsi:type="int" name="subscription_amount" nullable="false" unsigned="true" comment="Alma subscription Price"/>
         <column xsi:type="varchar" name="contract_id" nullable="false" length="255"  comment="Alma contract ID"/>
         <column xsi:type="varchar" name="cms_reference" nullable="false" length="255" comment="cms reference - SKU"/>

--- a/i18n/en_US.csv
+++ b/i18n/en_US.csv
@@ -161,7 +161,7 @@
 "Increment Id", "Increment Id"
 "Insurance contract", "Insurance contract"
 "Subscription Id", "Subscription Id"
-"Insurance Price", "Insurance Price"
+"Subscription reference", "Subscription reference"
 "Insured product", "Insured product"
 "State", "State"
 "Cancellation Date", "Cancellation Date"

--- a/i18n/fr_FR.csv
+++ b/i18n/fr_FR.csv
@@ -160,7 +160,7 @@
 "Alma Subscription details for Order", "Alma Subscription details for Order"
 "Increment Id", "Numéro de commande"
 "Insurance contract", "Contrat de souscription"
-"Subscription Id", "Id de souscription"
+"Subscription reference", "Référence de la souscription"
 "Insurance Price", "Prix de l'assurance"
 "Insured product", "Produit assuré"
 "State", "Etat"

--- a/view/adminhtml/templates/insurance/subscription/details.phtml
+++ b/view/adminhtml/templates/insurance/subscription/details.phtml
@@ -10,7 +10,7 @@
         class="subscription-alma-iframe"
         width="100%"
         height="100%"
-        src="https://protect.staging.almapay.com/almaBackOfficeSubscriptions.html">
+        src="<?= $block->getOrderDetailsUrl() ?>">
     </iframe>
     <div id="alma-insurance-modal"></div>
 </div>

--- a/view/adminhtml/ui_component/subscription_grid_listing.xml
+++ b/view/adminhtml/ui_component/subscription_grid_listing.xml
@@ -60,10 +60,10 @@
                 <label translate="true">Insurance contract</label>
             </settings>
         </column>
-        <column name="subscription_broker_id">
+        <column name="subscription_broker_reference">
             <settings>
                 <filter>text</filter>
-                <label translate="true">Subscription Id</label>
+                <label translate="true">Subscription reference</label>
             </settings>
         </column>
         <column name="subscription_amount">

--- a/view/adminhtml/web/js/subscription_details.js
+++ b/view/adminhtml/web/js/subscription_details.js
@@ -54,7 +54,6 @@ define([
 
             function getCmsSubscriptions(subscriptions) {
                 return subscriptions.map(subscription => {
-                    console.log(subscription);
                     return {
                         id: subscription.entity_id,
                         productName: subscription.linked_product_name,
@@ -63,6 +62,7 @@ define([
                         status: subscription.subscription_state,
                         subscriptionId: subscription.subscription_id,
                         subscriptionBrokerId: subscription.subscription_broker_id,
+                        subscriptionBrokerReference: subscription.subscription_broker_reference,
                         subscriptionAmount: subscription.subscription_amount,
                         isRefunded: subscription.is_refunded === '1',
                         reasonForCancelation: subscription.reason_of_cancelation,


### PR DESCRIPTION
### Reason for change

<!-- Describe here the reason for change, and provide a link to the corresponding ClickUp task or Sentry issue. -->

[Linear task](https://linear.app/almapay/issue/ECOM-1526/[🧩-ac]-store-reference-and-send-it-to-iframe)

### Code changes

- add reference on get subscription
- set reference in iframe details order
- dynamique url for iframe detail order
- update unit test
<!-- Describe here the code changes at a high level. Anything that can help reviewers review your PR. -->

### How to test

buy insurance and see the reference in the table order detail
and see the url of the iframe in the console
_As a reviewer, you are encouraged to test the PR locally._

<!-- Describe here how to test your changes, if applicable. Insert UI screenshots when relevant -->

### Checklist for authors and reviewers

<!-- Move to the next section the non applicable items -->

- [ ] The title of the PR uses business wording, not technical jargon, for the changelog readers to understand it
- [ ] The PR implements the changes asked in the referenced task / issue
- [ ] The automated tests are compliant with the [testing strategy](https://www.notion.so/almapay/Backend-testing-strategy-06c642cec1bf47b9b8feca3a91ea8d4a)
- [ ] The tests are relevant, and cover the corner/error cases, not only the happy path
- [ ] You understand the impact of this PR on existing code/features
- [ ] The changes include adequate logging and Datadog traces
- [ ] Documentation is updated (API, developer documentation, ADR, Notion...)

### Non applicable

<!-- Move here non applicable items of the checklist, if any -->
