### PR TITLE
Implement call to ordersstatus in cms

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,10 @@
 Changelog
 =========
 
+v4.3.0
+------
+* feat : data analysis for improved customer experience
+
 v4.2.0
 ------
 * feat : Deferred Payments with In page checkout

--- a/Model/Exceptions/OrderStatusException.php
+++ b/Model/Exceptions/OrderStatusException.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace Alma\MonthlyPayments\Model\Exceptions;
+
+use Exception;
+
+class OrderStatusException extends Exception
+{
+    public function __construct($message, $logger, $code = 0, \Throwable $previous = null)
+    {
+        parent::__construct($message, $code, $previous);
+        $logger->warning($message);
+        if (isset($previous)) {
+            $logger->warning(sprintf('Previous exception message : %s', $previous->getMessage()));
+        }
+    }
+}

--- a/Observer/OrderStatusObserver.php
+++ b/Observer/OrderStatusObserver.php
@@ -1,0 +1,116 @@
+<?php
+
+namespace Alma\MonthlyPayments\Observer;
+
+use Alma\API\Client;
+use Alma\API\Entities\Order as AlmaOrder;
+use Alma\API\Entities\Payment;
+use Alma\API\Exceptions\AlmaException;
+use Alma\MonthlyPayments\Gateway\Config\Config;
+use Alma\MonthlyPayments\Helpers\AlmaClient;
+use Alma\MonthlyPayments\Helpers\Exceptions\AlmaClientException;
+use Alma\MonthlyPayments\Helpers\Logger;
+use Alma\MonthlyPayments\Model\Exceptions\OrderStatusException;
+use Magento\Framework\Event\Observer;
+use Magento\Framework\Event\ObserverInterface;
+use Magento\Sales\Model\Order;
+
+class OrderStatusObserver implements ObserverInterface
+{
+    private $logger;
+    private $almaClient;
+
+    public function __construct(
+        Logger     $logger,
+        AlmaClient $almaClient
+    ) {
+        $this->logger = $logger;
+        $this->almaClient = $almaClient;
+    }
+
+    /**
+     * @param Observer $observer
+     * @return void
+     */
+    public function execute(Observer $observer)
+    {
+        /** @var Order $order */
+        $order = $observer->getEvent()->getData('order');
+        $payment = $order->getPayment();
+
+        if (
+            $order->getState() === Order::STATE_NEW
+            || !$payment
+            || $payment->getMethod() !== Config::CODE
+            || !array_key_exists(Config::ORDER_PAYMENT_ID, $payment->getAdditionalInformation())
+        ) {
+            return;
+        }
+
+        $almaPaymentId = $payment->getAdditionalInformation()[Config::ORDER_PAYMENT_ID];
+
+        try {
+            $almaClient = $this->getAlmaClient();
+            $almaPayment = $this->getAlmaPayment($almaClient, $almaPaymentId);
+            $almaOrder = $this->getAlmaOrder($almaPayment, $order->getIncrementId());
+        } catch (OrderStatusException $e) {
+            $this->logger->error('OrderStatus Exception :', [$e->getMessage()]);
+            return;
+        }
+
+        try {
+            $almaClient->orders->sendStatus($almaOrder->id, ['status' => $order->getStatus() ?? '', 'is_shipped' => $order->hasShipments()]);
+        } catch (AlmaException $e) {
+            $this->logger->error('Impossible to send order Status', [$e->getMessage()]);
+        }
+    }
+
+    /**
+     * @return Client
+     * @throws OrderStatusException
+     */
+    private function getAlmaClient(): Client
+    {
+        try {
+            return $this->almaClient->getDefaultClient();
+        } catch (AlmaClientException $e) {
+            throw new OrderStatusException('Impossible to initialize Alma', $this->logger, 0, $e);
+        }
+    }
+
+    /**
+     * @param Client $almaClient
+     * @param string $almaPaymentId
+     * @return Payment
+     * @throws OrderStatusException
+     */
+    private function getAlmaPayment(Client $almaClient, string $almaPaymentId): Payment
+    {
+        try {
+            return $almaClient->payments->fetch($almaPaymentId);
+        } catch (AlmaException $e) {
+            throw new OrderStatusException('Impossible to fetch Payment', $this->logger, 0, $e);
+        }
+    }
+
+
+    /**
+     * @param Payment $almaPayment
+     * @param string $incrementId
+     * @return AlmaOrder
+     * @throws OrderStatusException
+     */
+    private function getAlmaOrder(Payment $almaPayment, string $incrementId): AlmaOrder
+    {
+        if (empty($almaPayment->orders)) {
+            throw new OrderStatusException(sprintf('No Orders in Alma payment %s', $almaPayment->id), $this->logger);
+        }
+        foreach ($almaPayment->orders as $order) {
+            if ($order->merchant_reference === $incrementId) {
+                return $order;
+            }
+        }
+        throw new OrderStatusException(sprintf('No Order with merchant reference %s in Alma payment %s', $incrementId, $almaPayment->id), $this->logger);
+    }
+
+}

--- a/Test/Unit/Observer/OrderStatusObserverTest.php
+++ b/Test/Unit/Observer/OrderStatusObserverTest.php
@@ -1,0 +1,189 @@
+<?php
+
+namespace Alma\MonthlyPayments\Test\Unit\Observer;
+
+use Alma\API\Client;
+use Alma\API\Endpoints\Orders;
+use Alma\API\Endpoints\Payments;
+use Alma\API\Entities\Order;
+use Alma\API\Entities\Payment;
+use Alma\MonthlyPayments\Gateway\Config\Config;
+use Alma\MonthlyPayments\Helpers\AlmaClient;
+use Alma\MonthlyPayments\Helpers\Logger;
+use Alma\MonthlyPayments\Observer\OrderStatusObserver;
+use Magento\Framework\Event;
+use Magento\Framework\Event\Observer;
+use PHPUnit\Framework\TestCase;
+
+class OrderStatusObserverTest extends TestCase
+{
+    private $logger;
+    private $observer;
+
+    private $event;
+    private $ordersEndpoint;
+    private $paymentsEndpoint;
+    private $almaClient;
+
+    protected function setUp(): void
+    {
+        $this->ordersEndpoint = $this->createMock(Orders::class);
+        $this->paymentsEndpoint = $this->createMock(Payments::class);
+
+        $client = $this->createMock(Client::class);
+        $client->orders = $this->ordersEndpoint;
+        $client->payments = $this->paymentsEndpoint;
+
+        $this->logger = $this->createMock(Logger::class);
+        $this->almaClient = $this->createMock(AlmaClient::class);
+        $this->almaClient->method('getDefaultClient')->willReturn($client);
+        $this->observer = $this->createMock(Observer::class);
+        $this->event = $this->createMock(Event::class);
+
+        $this->observer->method('getEvent')->willReturn($this->event);
+    }
+
+    private function createOrderStatusObserverObject(): OrderStatusObserver
+    {
+        return new OrderStatusObserver(
+            $this->logger,
+            $this->almaClient
+        );
+    }
+
+    public function testGivenOrderStateIsNewShouldReturnVoid(): void
+    {
+        $order = $this->createMock(\Magento\Sales\Model\Order::class);
+        $order->method('getState')->willReturn('new');
+        $orderStatusObserver = $this->createOrderStatusObserverObject();
+        $this->event->method('getData')->willReturn($order);
+        $this->ordersEndpoint->expects($this->never())->method('sendStatus');
+        $orderStatusObserver->execute($this->observer);
+    }
+
+    public function testGivenProcessingOrderWithNonAlmaPaymentMethodShouldNotCallAlmaAndReturnVoid(): void
+    {
+        $payment = $this->createMock(\Magento\Sales\Model\Order\Payment::class);
+        $payment->method('getMethod')->willReturn('not_alma');
+
+        $order = $this->createMock(\Magento\Sales\Model\Order::class);
+        $order->method('getState')->willReturn('processing');
+        $order->method('getPayment')->willReturn($payment);
+
+        $orderStatusObserver = $this->createOrderStatusObserverObject();
+        $this->event->method('getData')->willReturn($order);
+        $this->ordersEndpoint->expects($this->never())->method('sendStatus');
+        $orderStatusObserver->execute($this->observer);
+    }
+
+    public function testGivenNoAlmaPaymentIdInAdditionalInformationMustReturnWithoutCallAlmaPayment(): void
+    {
+        $payment = $this->createMock(\Magento\Sales\Model\Order\Payment::class);
+        $payment->method('getMethod')->willReturn(Config::CODE);
+        $payment->method('getAdditionalInformation')->willReturn([]);
+
+        $order = $this->createMock(\Magento\Sales\Model\Order::class);
+        $order->method('getState')->willReturn('processing');
+        $order->method('getStatus')->willReturn('processing_status');
+        $order->method('getPayment')->willReturn($payment);
+
+        $this->event->method('getData')->willReturn($order);
+
+
+        $this->paymentsEndpoint->expects($this->never())->method('fetch');
+        $this->createOrderStatusObserverObject()->execute($this->observer);
+
+    }
+
+    public function testGivenAnAlmaPaymentWithoutOrdersShouldNotCallSendStatus(): void
+    {
+        $payment = $this->createMock(\Magento\Sales\Model\Order\Payment::class);
+        $payment->method('getMethod')->willReturn(Config::CODE);
+        $payment->method('getAdditionalInformation')->willReturn([Config::ORDER_PAYMENT_ID => 'alma_payment_external_id']);
+
+        $order = $this->createMock(\Magento\Sales\Model\Order::class);
+        $order->method('getState')->willReturn('processing');
+        $order->method('getPayment')->willReturn($payment);
+        $order->method('getIncrementId')->willReturn('100000013');
+
+        $this->event->method('getData')->willReturn($order);
+        $almaPayment = $this->createMock(Payment::class);
+        $almaPayment->orders = [];
+
+        $this->paymentsEndpoint->expects($this->once())->method('fetch')->with('alma_payment_external_id')->willReturn($almaPayment);
+        $this->ordersEndpoint->expects($this->never())->method('sendStatus');
+        $this->createOrderStatusObserverObject()->execute($this->observer);
+    }
+
+    public function testGivenAnAlmaPaymentWithOrdersWithBadMerchantReferenceShouldNotCallSendStatus(): void
+    {
+        $payment = $this->createMock(\Magento\Sales\Model\Order\Payment::class);
+        $payment->method('getMethod')->willReturn(Config::CODE);
+        $payment->method('getAdditionalInformation')->willReturn([Config::ORDER_PAYMENT_ID => 'alma_payment_external_id']);
+
+        $order = $this->createMock(\Magento\Sales\Model\Order::class);
+        $order->method('getState')->willReturn('processing');
+        $order->method('getPayment')->willReturn($payment);
+        $order->method('getIncrementId')->willReturn('100000013');
+
+        $this->event->method('getData')->willReturn($order);
+        $almaPayment = $this->createMock(Payment::class);
+
+        $almaOrder = $this->createMock(Order::class);
+        $almaOrder->merchant_reference = '100000012';
+        $almaOrder2 = $this->createMock(Order::class);
+        $almaOrder2->merchant_reference = '100000014';
+        $almaPayment->orders = [$almaOrder, $almaOrder2];
+
+        $this->paymentsEndpoint->expects($this->once())->method('fetch')->with('alma_payment_external_id')->willReturn($almaPayment);
+        $this->ordersEndpoint->expects($this->never())->method('sendStatus');
+        $this->createOrderStatusObserverObject()->execute($this->observer);
+    }
+
+    /**
+     * @dataProvider orderStatusDataProvider
+     */
+    public function testGivenProcessingOrderWithAlmaPaymentMethodShouldCallAlmaSendStatusAndReturnVoid($dataProvider): void
+    {
+        $payment = $this->createMock(\Magento\Sales\Model\Order\Payment::class);
+        $payment->method('getMethod')->willReturn(Config::CODE);
+        $payment->method('getAdditionalInformation')->willReturn([Config::ORDER_PAYMENT_ID => 'alma_payment_external_id']);
+
+        $order = $this->createMock(\Magento\Sales\Model\Order::class);
+        $order->method('getState')->willReturn('processing');
+        $order->method('getStatus')->willReturn($dataProvider['status']);
+        $order->method('getPayment')->willReturn($payment);
+        $order->method('hasShipments')->willReturn($dataProvider['is_shipped']);
+        $order->method('getIncrementId')->willReturn('100000013');
+
+        $this->event->method('getData')->willReturn($order);
+
+        $almaOrder = $this->createMock(Order::class);
+        $almaOrder->id = 'alma_order_external_id';
+        $almaOrder->merchant_reference = '100000013';
+        $almaPayment = $this->createMock(Payment::class);
+        $almaPayment->orders = [$almaOrder];
+
+        $this->paymentsEndpoint->expects($this->once())->method('fetch')->with('alma_payment_external_id')->willReturn($almaPayment);
+        $this->ordersEndpoint->expects($this->once())->method('sendStatus')->with('alma_order_external_id', ['status' => $dataProvider['status'], 'is_shipped' => $dataProvider['is_shipped']]);
+        $this->createOrderStatusObserverObject()->execute($this->observer);
+    }
+
+    private function orderStatusDataProvider(): array
+    {
+        return [
+            'Test with an empty status' => [
+                [
+                    'status' => null,
+                    'is_shipped' => false,
+                ]
+            ],
+            'Test with an string status' => [
+                [
+                    'status' => 'status_pending',
+                    'is_shipped' => true,
+                ]
+            ],
+        ];
+    }
+}

--- a/composer.json
+++ b/composer.json
@@ -3,10 +3,10 @@
     "description": "Integrates Alma Monthly Payments into Magento 2",
     "require": {
         "php": ">=7.1",
-        "alma/alma-php-client": ">=1.11.0"
+        "alma/alma-php-client": ">=2.0.7"
     },
     "type": "magento2-module",
-    "version": "4.2.0",
+    "version": "4.3.0",
     "license": [
         "MIT"
     ],

--- a/etc/events.xml
+++ b/etc/events.xml
@@ -27,4 +27,7 @@
         <observer name="alma_monthly_payments_gateway_data_assign"
                   instance="Alma\MonthlyPayments\Observer\PaymentDataAssignObserver"/>
     </event>
+    <event name="sales_order_save_after">
+        <observer name="sales_order_save_after_order_status" instance="Alma\MonthlyPayments\Observer\OrderStatusObserver" />
+    </event>
 </config>

--- a/etc/module.xml
+++ b/etc/module.xml
@@ -27,7 +27,7 @@
 
 <config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
         xsi:noNamespaceSchemaLocation="urn:magento:framework:Module/etc/module.xsd">
-    <module name="Alma_MonthlyPayments" setup_version="4.2.0">
+    <module name="Alma_MonthlyPayments" setup_version="4.3.0">
         <sequence>
             <module name="Magento_Sales"/>
             <module name="Magento_Payment"/>


### PR DESCRIPTION
### Reason for change

<!-- Describe here the reason for change, and provide a link to the corresponding ClickUp task or Sentry issue. -->
Implement
[Linear task](https://linear.app/almapay/issue/ECOM-1683/[🧩-ac]-implement-call-to-ordersstatus-in-cms)

### Code changes

Trigger all orders Status change and check they are payed with Alma
Send Status to Alma

<!-- Describe here the code changes at a high level. Anything that can help reviewers review your PR. -->

### How to test

_As a reviewer, you are encouraged to test the PR locally._

<!-- Describe here how to test your changes, if applicable. Insert UI screenshots when relevant -->

### Checklist for authors and reviewers

<!-- Move to the next section the non applicable items -->

- [X] The title of the PR uses business wording, not technical jargon, for the changelog readers to understand it
- [X] The PR implements the changes asked in the referenced task / issue
- [X] The automated tests are compliant with the [testing strategy](https://www.notion.so/almapay/Backend-testing-strategy-06c642cec1bf47b9b8feca3a91ea8d4a)
- [X] The tests are relevant, and cover the corner/error cases, not only the happy path
- [X] You understand the impact of this PR on existing code/features
- [X] The changes include adequate logging and Datadog traces

### Non applicable
- [ ] Documentation is updated (API, developer documentation, ADR, Notion...)

<!-- Move here non applicable items of the checklist, if any -->
