### PR TITLE
[DEX-866] Add infos in PR about E2E tests run status

### DIFF
--- a/.github/workflows/e2e-test-post-results.yml
+++ b/.github/workflows/e2e-test-post-results.yml
@@ -1,0 +1,81 @@
+name: Post E2E results in pull request
+
+on:
+  workflow_dispatch:
+    inputs:
+      pr-number:
+        type: string
+        description: The PR number in which to post the results
+        required: true
+      e2e-status:
+        type: string
+        description: The status of the E2E tests (failure or success)
+        required: true
+      e2e-run-url:
+        type: string
+        description: The URL of the E2E tests run
+        required: true
+      check-id:
+        type: string
+        description: Github check ID of the E2E tests in the pull request
+        required: true
+
+jobs:
+
+  e2e-post-results:
+    runs-on: ubuntu-22.04
+
+    steps:
+
+      - name: Add a comment with E2E tests results in the Pull Request
+        uses: actions/github-script@v7
+        with:
+            script: |
+              let commentBody = '❌ E2E tests have failed. \n';
+              if ('${{ github.event.inputs.e2e-status }}' === 'success') {
+                  commentBody = '✅ E2E tests have been successfully completed. \n';
+              }
+              commentBody += '➡️ You can find the results [here](${{ github.event.inputs.e2e-run-url }}).';
+              commentBody += '\n\n<!-- id:e2e-test-run-info -->';
+              github.rest.issues.createComment({
+                  issue_number: ${{ github.event.inputs.pr-number }},
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  body: commentBody
+              })
+
+
+      - name: Generate Github token for PR checks
+        id: github-token-checks
+        uses: actions/create-github-app-token@v1
+        continue-on-error: true
+        with:
+          app-id: ${{ secrets.ALMA_UPDATE_CHECKS_APP_ID }}
+          private-key: ${{ secrets.ALMA_UPDATE_CHECKS_APP_PEM }}
+          repositories: alma-monthlypayments-magento2
+
+      - name: Update check in PR with E2E tests results
+        uses: actions/github-script@v7
+        with:
+          github-token: ${{ steps.github-token-checks.outputs.token }}
+          script: |
+            let checkStatus = 'completed';
+            let checkConclusion = 'success';
+            let checkOutput = {
+              title: 'E2E tests',
+              summary: '✅ E2E tests have been successfully completed',
+              text: `➡️ You can find the results [here](${{ github.event.inputs.e2e-run-url }}).`
+            };
+            if ('${{ github.event.inputs.e2e-status }}' === 'failure') {
+              checkConclusion = 'failure';
+              checkOutput.summary = '❌ E2E tests have failed.';
+            }
+            github.rest.checks.update({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              check_run_id: '${{ github.event.inputs.check-id }}',
+              status: checkStatus,
+              conclusion: checkConclusion,
+              output: checkOutput
+            })
+

--- a/.github/workflows/e2e-test.yaml
+++ b/.github/workflows/e2e-test.yaml
@@ -55,7 +55,7 @@ jobs:
       id: e2e-tests-workflow-dispatch
       with:
           token: ${{ steps.github-token-infrastructure.outputs.token }}
-          ref: devx/dex-866-improve-e2e-status-update-on-pr
+          ref: main
           repo: integration-infrastructure
           owner: alma
           workflow: deploy-cms.yaml

--- a/.github/workflows/e2e-test.yaml
+++ b/.github/workflows/e2e-test.yaml
@@ -12,60 +12,104 @@ jobs:
       matrix:
         version:
         - 2.4.6
-    runs-on: ubuntu-latest
-    if: github.event.pull_request.draft == false
-    steps:
-    - name: Get only last part of branch name in $SLUG_VERSION env var
-      run:  |
-        VERSION=${{ matrix.version }}
-        echo "SLUG_VERSION=${VERSION//./-}" >> $GITHUB_ENV
+    runs-on: ubuntu-22.04
+    if: github.event.pull_request.draft == false && !contains(github.event.pull_request.labels.*.name, 'hotfix')
 
-    - name: Generate token
-      id: generate_token
-      uses: tibdex/github-app-token@v1.8.0
+    steps:
+
+    - name: Generate Github token for PR checks
+      id: github-token-checks
+      uses: actions/create-github-app-token@v1
       continue-on-error: true
       with:
-        app_id: ${{ secrets.ALMA_UPDATE_CHECKS_APP_ID }}
-        private_key: ${{ secrets.ALMA_UPDATE_CHECKS_APP_PEM }}
+        app-id: ${{ secrets.ALMA_UPDATE_CHECKS_APP_ID }}
+        private-key: ${{ secrets.ALMA_UPDATE_CHECKS_APP_PEM }}
+        repositories: alma-monthlypayments-magento2
 
-    - uses: LouisBrunner/checks-action@v2.0.0
-      id: e2e_status
+    - name: Create a Github check for E2E tests run in the Pull Request
+      if: github.event_name == 'pull_request'
+      uses: actions/github-script@v7
+      id: create-github-check
       with:
-        token: ${{ steps.generate_token.outputs.token }}
-        name: E2E Test / result (${{ matrix.version }})
-        status: "in_progress"
+          github-token: ${{ steps.github-token-checks.outputs.token }}
+          script: |
+              const check = await github.rest.checks.create({
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  name: 'E2E tests results',
+                  head_sha: '${{ github.event.pull_request.head.sha }}',
+                  status: "in_progress",
+              })
+              core.setOutput('id', check.data.id)
 
     - name: Generate Github token for integration-infrastructure repo
-      id: generate_github_token
-      uses: tibdex/github-app-token@v1
+      id: github-token-infrastructure
+      uses: actions/create-github-app-token@v1
       with:
-        app_id: ${{ secrets.ALMA_WF_TRIGGER_APP_ID }}
-        private_key: ${{ secrets.ALMA_WF_TRIGGER_APP_PEM }}
-        installation_id: ${{ secrets.ALMA_WF_TRIGGER_INSTALLATION_ID }}
-        repository: alma/integration-infrastructure
+        app-id: ${{ secrets.ALMA_WF_TRIGGER_APP_ID }}
+        private-key: ${{ secrets.ALMA_WF_TRIGGER_APP_PEM }}
+        repositories: integration-infrastructure
 
-    - name: Invoke e2e workflow with inputs
-      uses: benc-uk/workflow-dispatch@v1.2.3
+    - name: Trigger E2E tests in the integration-infrastructure repository
+      uses: codex-/return-dispatch@v1
+      id: e2e-tests-workflow-dispatch
       with:
-        workflow: Deploy CMS
-        token: ${{ steps.generate_github_token.outputs.token }}
-        repo: alma/integration-infrastructure
-        ref: main
-        inputs: >
-          {
-            "name": "e2e-${{ github.run_id }}",
-            "alma_plugin_branch": "${{ github.head_ref || github.ref_name }}",
-            "alma_plugin_test_branch" : "main",
-            "alma_plugin_enabled" : "1",
-            "cms": "adobe-commerce-${{ matrix.version }}",
-            "e2e": "true",
-            "e2e_check_id": "${{ steps.e2e_status.outputs.check_id }}",
-            "e2e_check_origin" : "${{ github.repository }}"
-          }
+          token: ${{ steps.github-token-infrastructure.outputs.token }}
+          ref: devx/dex-866-improve-e2e-status-update-on-pr
+          repo: integration-infrastructure
+          owner: alma
+          workflow: deploy-cms.yaml
+          workflow_inputs: '{
+              "name": "e2e-${{ github.run_id }}",
+              "alma_plugin_branch": "${{ github.head_ref || github.ref_name }}",
+              "alma_plugin_test_branch" : "main",
+              "cms":"adobe-commerce-${{ matrix.version }}",
+              "e2e": "true",
+              "e2e_check_info" : "{
+                  \"repository\": \"${{ github.event.repository.name }}\",
+                  \"pr_number\": \"${{ github.event.number }}\",
+                  \"check_id\": \"${{ steps.create-github-check.outputs.id  }}\"
+                  }"
+              }'
+          workflow_timeout_seconds: 120 # Default: 300
 
-    - uses: LouisBrunner/checks-action@v2.0.0
-      if: failure()
+    - name: Hide deprecated E2E test run info message
+      uses: int128/hide-comment-action@v1
       with:
-        token: ${{ steps.generate_token.outputs.token }}
-        check_id: ${{ steps.e2e_status.outputs.check_id }}
-        conclusion: failure
+        # This string should be kept in sync with the last words of the comment in :
+        # `Send a comment to the PR informing that the E2E tests are running` step (in this workflow).
+        # `Add a comment with E2E tests results in the Pull Request` step (in e2e-test-post-results workflow)
+        contains: <!-- id:e2e-test-run-info -->
+
+    - name: Send a comment to the PR informing that the E2E tests are running
+      if: github.event_name == 'pull_request'
+      uses: actions/github-script@v7
+      with:
+          script: |
+              github.rest.issues.createComment({
+                  issue_number: context.issue.number,
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  body: '⏳E2E tests are currently running. \n' +
+                      '➡️ You can follow their progression [here](${{steps.e2e-tests-workflow-dispatch.outputs.run_url}}).' +
+                      '\n\n<!-- id:e2e-test-run-info -->'
+              })
+
+    - name: Update Github check with the E2E tests run URL
+      if: github.event_name == 'pull_request'
+      uses: actions/github-script@v7
+      with:
+          github-token: ${{ steps.github-token-checks.outputs.token }}
+          script: |
+              const checkOutput = {
+                  title: 'E2E tests results',
+                  summary: '⏳E2E tests are currently running.',
+                  text: '➡️ You can follow their progression [here](${{steps.e2e-tests-workflow-dispatch.outputs.run_url}}).'
+              };
+              github.rest.checks.update({
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  check_run_id: '${{ steps.create-github-check.outputs.id }}',
+                  output: checkOutput
+              })
+


### PR DESCRIPTION
### Reason for change

<!-- Describe here the reason for change, and provide a link to the corresponding ClickUp task or Sentry issue. -->

https://linear.app/almapay/issue/DEX-866/prestashop-improve-e2e-status-update-on-pr

### Code changes

<!-- Describe here the code changes at a high level. Anything that can help reviewers review your PR. -->
* Add a comment in the Pull Request with the link to the E2E tests run when they are triggered
* Update the Pull Request Check with this link
* Add a comment in the Pull Request when tests are finished with the result (success or failure)
* Update the Pull Request Check with the result (success or failure)

![image](https://github.com/alma/alma-monthlypayments-magento2/assets/131184161/2cb142c4-2065-4197-8703-ede42676b782)
![image](https://github.com/alma/alma-monthlypayments-magento2/assets/131184161/f97557ca-2a2d-41ff-be7c-ad5a46783b0a)
![image](https://github.com/alma/alma-monthlypayments-magento2/assets/131184161/bf007383-8a8b-48e2-8029-b840e842d4bb)



