### PR TITLE
[DEX-890] Add release drafter template

### DIFF
--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -1,0 +1,21 @@
+name-template: 'v$RESOLVED_VERSION'
+tag-template: 'v$RESOLVED_VERSION'
+
+template: |
+
+  $CHANGES
+
+change-template: '- $TITLE'
+change-title-escapes: '\<*_&#@`'
+version-resolver:
+  major:
+    labels:
+      - 'major'
+  minor:
+    labels:
+      - 'minor'
+      - 'type: feature'
+  patch:
+    labels:
+      - 'patch'
+  default: patch


### PR DESCRIPTION
### Reason for change

This is required to test the release workflow in https://github.com/alma/alma-monthlypayments-magento2/pull/155 :
The template for release-drafter must exist in the default branch

### Code changes

<!-- Describe here the code changes at a high level. Anything that can help reviewers review your PR. -->
This adds a really simple template for release-drafter