### PR TITLE
Add commit name rule

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,16 @@
+# See <https://pre-commit.com> for more information
+# See <https://pre-commit.com/hooks.html> for more hooks
+repos:
+  - repo: https://github.com/commitizen-tools/commitizen
+    rev: v3.27.0
+    hooks:
+      - id: commitizen
+        name: Check commit message format
+        stages: [ commit-msg ]
+  - repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: v4.6.0
+    hooks:
+      - id: check-added-large-files
+        args: ["--maxkb=1024"]
+      - id: detect-private-key
+      - id: check-merge-conflict

--- a/cz.yaml
+++ b/cz.yaml
@@ -1,0 +1,7 @@
+---
+commitizen:
+  name: cz_conventional_commits
+  tag_format: v$version
+  update_changelog_on_bump: true
+  version: 4.1.1
+  version_scheme: semver


### PR DESCRIPTION
Add commit-message check to respect commitizen convention on pre-commit

How to test : 

- Install commit-msg hook `pre-commit install --hook-type commit-msg` 
- Make any change (like delete a work in the README.md)
- `git add`
- `git commit -m "wrong commit message"`
- pre-commit hook should block your commit as the commit message does not meet the commitizen convention, you should see
```
commit validation: failed!
please enter a commit message in the commitizen format.
commit "": "wrong commit message"
pattern: (?s)(build|ci|docs|feat|fix|perf|refactor|style|test|chore|revert|bump)(\(\S+\))?!?:( [^\n\r]+)((\n\n.*)|(\s*))?$
```

- Try a commit message that respects the convention, for example `git commit -m "test(pr): commit test for pr"`
- Your commit should be created correctly
- Do not push anything of course

You're good to go to write amazing commit messages.

See the commitizen convention for reference https://www.conventionalcommits.org/en/v1.0.0/#summary
See the POS documentation that uses the same rules for reference as well https://pos-doc.alma.tech/developing/contributing/todo/contributing/#commit-name

See our best practices guide for review https://www.notion.so/almapay/Definition-of-review-3f254e05381f4ccaac895396139110a5?pvs=4#28f094431a6045bc8b0a0facddafb9de