### PR TITLE
Fix insurance qty subscription

### DIFF
--- a/Helpers/InsuranceHelper.php
+++ b/Helpers/InsuranceHelper.php
@@ -380,7 +380,7 @@ class InsuranceHelper extends AbstractHelper
                         $insuranceData['id'],
                         $insuranceData['price'],
                         $insuranceData['parent_sku'],
-                        Functions::priceToCents($orderItem->getOriginalPrice()),
+                        $insuranceData['parent_price'],
                         $subscriber,
                         $this->getCallbackUrl()
                     );

--- a/Helpers/InsuranceHelper.php
+++ b/Helpers/InsuranceHelper.php
@@ -190,7 +190,7 @@ class InsuranceHelper extends AbstractHelper
             return null;
         }
 
-        return new InsuranceProduct($insuranceContract, $addedItemToQuote->getName(), $addItemPrice);
+        return new InsuranceProduct($insuranceContract, $parentSku, $addedItemToQuote->getName(), $addItemPrice);
     }
 
     /**
@@ -370,7 +370,7 @@ class InsuranceHelper extends AbstractHelper
             $orderItem = $item->getOrderItem();
             $orderItemQty = (int)$item->getQty();
             $insuranceData = $orderItem->getData(InsuranceHelper::ALMA_INSURANCE_DB_KEY);
-            if (!$insuranceData || $item->getSku() === InsuranceHelper::ALMA_INSURANCE_SKU) {
+            if (!$insuranceData || $item->getSku() !== InsuranceHelper::ALMA_INSURANCE_SKU) {
                 continue;
             }
             $insuranceData = json_decode($insuranceData, true);
@@ -379,7 +379,7 @@ class InsuranceHelper extends AbstractHelper
                     $subscriptionArray[] = new Subscription(
                         $insuranceData['id'],
                         $insuranceData['price'],
-                        $item->getSku(),
+                        $insuranceData['parent_sku'],
                         Functions::priceToCents($orderItem->getOriginalPrice()),
                         $subscriber,
                         $this->getCallbackUrl()

--- a/Model/Data/InsuranceProduct.php
+++ b/Model/Data/InsuranceProduct.php
@@ -24,21 +24,27 @@ class InsuranceProduct
      * @var string
      */
     private $parentName;
+    /**
+     * @var string
+     */
+    private $parentSku;
 
     /**
      * @param Contract $contract
+     * @param string $parentSku
      * @param string $parentName
      * @param float $parentPrice
      * @param int|null $linkToken
      */
     public function __construct(
         Contract         $contract,
+        string           $parentSku,
         string           $parentName,
         float            $parentPrice,
         int              $linkToken = null
-    )
-    {
+    ) {
         $this->linkToken = $linkToken;
+        $this->parentSku = $parentSku;
         $this->parentName = $parentName;
         $this->parentPrice = $parentPrice;
         $this->contract = $contract;
@@ -87,6 +93,7 @@ class InsuranceProduct
             'price' => $this->getPrice(),
             'duration_year' => $this->getDurationYear(),
             'link' => $this->getLinkToken(),
+            'parent_sku' => $this->getParentSku(),
             'parent_name' => $this->getParentName(),
             'parent_price' => $this->getParentPrice(),
             'files' => $this->getFiles()
@@ -116,6 +123,14 @@ class InsuranceProduct
     public function getParentName(): string
     {
         return $this->parentName;
+    }
+
+    /**
+     * @return string
+     */
+    public function getParentSku(): string
+    {
+        return $this->parentSku;
     }
 
     /**

--- a/Test/Unit/Helpers/InsuranceHelperTest.php
+++ b/Test/Unit/Helpers/InsuranceHelperTest.php
@@ -564,7 +564,6 @@ class InsuranceHelperTest extends TestCase
         $itemInsurance = $this->invoiceItemFactory(InsuranceHelper::ALMA_INSURANCE_SKU, true);
         $itemInsurance->method('getQty')->willReturn('1.00000');
         $collectionWithoutInsurance = $this->newCollectionFactory([$itemWithInsurance1, $itemInsurance, $itemWithoutInsurance2]);
-        $subscription = $this->subscriptionFactory($subscriber);
         $subscriptionArray = $this->insuranceHelper->getSubscriptionData($collectionWithoutInsurance, $subscriber);
         $this->assertContainsOnlyInstancesOf(Subscription::class, $subscriptionArray);
         foreach ($subscriptionArray as $key => $subscription) {
@@ -754,18 +753,6 @@ class InsuranceHelperTest extends TestCase
         foreach ($expected as $key => $result) {
             $this->assertEquals($result, $arraySubscriptionResult[$key]->getData());
         }
-    }
-
-    private function subscriptionFactory(Subscriber $subscriber, string $contractId = 'contract_id_123', string $sku = 'mySku', int $amount = 11): Subscription
-    {
-        return new Subscription(
-            $contractId,
-            $amount,
-            $sku,
-            12012,
-            $subscriber,
-            'https://my-website.com/rest/V1/alma/insurance/update'
-        );
     }
 
     private function newCollectionFactory(array $items): Collection

--- a/Test/Unit/Helpers/InsuranceHelperTest.php
+++ b/Test/Unit/Helpers/InsuranceHelperTest.php
@@ -567,10 +567,10 @@ class InsuranceHelperTest extends TestCase
         $subscription = $this->subscriptionFactory($subscriber);
         $subscriptionArray = $this->insuranceHelper->getSubscriptionData($collectionWithoutInsurance, $subscriber);
         $this->assertContainsOnlyInstancesOf(Subscription::class, $subscriptionArray);
-        foreach ([$subscription] as $key => $subscription) {
+        foreach ($subscriptionArray as $key => $subscription) {
             $this->assertEquals($subscription->getContractId(), $subscriptionArray[$key]->getContractId());
             $this->assertEquals($subscription->getCmsReference(), $subscriptionArray[$key]->getCmsReference());
-            $this->assertEquals($subscription->getProductPrice(), $subscriptionArray[$key]->getProductPrice());
+            $this->assertEquals(5300, $subscriptionArray[$key]->getProductPrice());
             $this->assertEquals($subscription->getSubscriber(), $subscriptionArray[$key]->getSubscriber());
             $this->assertTrue(boolval($subscriptionArray[$key]->getSubscriber()));
         }
@@ -592,7 +592,7 @@ class InsuranceHelperTest extends TestCase
         foreach ($subscriptionArray as $key => $subscription) {
             $this->assertEquals($subscription->getContractId(), $subscriptionArray[$key]->getContractId());
             $this->assertEquals($subscription->getCmsReference(), $subscriptionArray[$key]->getCmsReference());
-            $this->assertEquals($subscription->getProductPrice(), $subscriptionArray[$key]->getProductPrice());
+            $this->assertEquals(5300, $subscriptionArray[$key]->getProductPrice());
             $this->assertEquals($subscription->getSubscriber(), $subscriptionArray[$key]->getSubscriber());
             $this->assertTrue(boolval($subscriptionArray[$key]->getSubscriber()));
         }
@@ -793,7 +793,6 @@ class InsuranceHelperTest extends TestCase
         $orderItem = $this->createMock(OrderItem::class);
         if ($hasInsuranceData) {
             $orderItem->method('getData')->willReturn($this->getInsuranceData('1234', $contractId, $price, $parentPrice));
-            $orderItem->method('getOriginalPrice')->willReturn(120.12);
             $orderItem->method('getOrderId')->willReturn($orderId);
             $orderItem->method('getItemId')->willReturn($orderItemId);
             $orderItem->method('getSku')->willReturn($sku);

--- a/Test/Unit/Helpers/InsuranceHelperTest.php
+++ b/Test/Unit/Helpers/InsuranceHelperTest.php
@@ -536,7 +536,7 @@ class InsuranceHelperTest extends TestCase
             500,
             []
         );
-        $insuranceProductExpected = new InsuranceProduct($contract, $parentName, 12.50);
+        $insuranceProductExpected = new InsuranceProduct($contract, 'superSku', $parentName, 12.50);
         $insuranceEndpoint = $this->createMock(Insurance::class);
         $insuranceEndpoint->method('getInsuranceContract')->with('alm_insurance_id123456789', 'superSku', 1250)->willReturn($contract);
         $almaClient = $this->createMock(Client::class);
@@ -576,20 +576,20 @@ class InsuranceHelperTest extends TestCase
         }
     }
 
-    public function testForCollectionProductWithQty2return2subscriptions(): void
+    public function testForCollectionProductWith5QtyAddedAnd2insuranceReturn2subscriptions(): void
     {
         $subscriber = $this->subscriberFactory();
         $itemWithInsurance1 = $this->invoiceItemFactory('mySku', true);
-        $itemWithInsurance1->method('getQty')->willReturn('2.00000');
+        $itemWithInsurance1->method('getQty')->willReturn('5.00000');
         $itemWithoutInsurance2 = $this->invoiceItemFactory('mySku2');
         $itemInsurance = $this->invoiceItemFactory(InsuranceHelper::ALMA_INSURANCE_SKU, true);
         $itemInsurance->method('getQty')->willReturn('2.00000');
 
         $collectionWithoutInsurance = $this->newCollectionFactory([$itemWithInsurance1, $itemInsurance, $itemWithoutInsurance2]);
-        $subscription = $this->subscriptionFactory($subscriber);
         $subscriptionArray = $this->insuranceHelper->getSubscriptionData($collectionWithoutInsurance, $subscriber);
         $this->assertContainsOnlyInstancesOf(Subscription::class, $subscriptionArray);
-        foreach ([$subscription, $subscription] as $key => $subscription) {
+        $this->assertTrue(count($subscriptionArray) === 2);
+        foreach ($subscriptionArray as $key => $subscription) {
             $this->assertEquals($subscription->getContractId(), $subscriptionArray[$key]->getContractId());
             $this->assertEquals($subscription->getCmsReference(), $subscriptionArray[$key]->getCmsReference());
             $this->assertEquals($subscription->getProductPrice(), $subscriptionArray[$key]->getProductPrice());
@@ -787,7 +787,8 @@ class InsuranceHelperTest extends TestCase
         string $contractId = 'contract_id_123',
         string $price = '11',
         int    $parentPrice = 5300
-    ): InvoiceItem {
+    ): InvoiceItem
+    {
         $invoiceItem = $this->createMock(InvoiceItem::class);
         $orderItem = $this->createMock(OrderItem::class);
         if ($hasInsuranceData) {
@@ -841,7 +842,7 @@ class InsuranceHelperTest extends TestCase
         if (!$linkToken) {
             return null;
         }
-        return '{"id":"' . $contractId . '","name":"Alma outillage thermique 3 ans (Vol + casse)","price":' . $price . ',"link":"' . $linkToken . '","parent_name":"Fusion Backpack", "parent_price":"' . $parentPrice . '"}';
+        return '{"id":"' . $contractId . '","name":"Alma outillage thermique 3 ans (Vol + casse)","price":' . $price . ',"link":"' . $linkToken . '","parent_name":"Fusion Backpack","parent_sku":"mySku", "parent_price":"' . $parentPrice . '"}';
     }
 
     private function getInsuranceDataWithType(string $type, string $linkToken = null): ?string
@@ -849,7 +850,7 @@ class InsuranceHelperTest extends TestCase
         if (!$linkToken) {
             return null;
         }
-        return '{"id":"contract_id_123","name":"Alma outillage thermique 3 ans (Vol + casse)","price":11,"link":"' . $linkToken . '","parent_name":"Fusion Backpack","type":"' . $type . '", "parent_price": "5300"}';
+        return '{"id":"contract_id_123","name":"Alma outillage thermique 3 ans (Vol + casse)","price":11,"link":"' . $linkToken . '","parent_name":"Fusion Backpack","parent_sku":"mySku","type":"' . $type . '", "parent_price": "5300"}';
     }
 
     private function quoteItemFactory(string $sku, string $linkToken = null): Item

--- a/Test/Unit/Model/Data/InsuranceProductTest.php
+++ b/Test/Unit/Model/Data/InsuranceProductTest.php
@@ -5,7 +5,6 @@ namespace Alma\MonthlyPayments\Test\Unit\Model\Data;
 
 use Alma\API\Entities\Insurance\Contract;
 use Alma\MonthlyPayments\Model\Data\InsuranceProduct;
-use Magento\Catalog\Api\Data\ProductInterface;
 use PHPUnit\Framework\TestCase;
 
 class InsuranceProductTest extends TestCase
@@ -21,11 +20,12 @@ class InsuranceProductTest extends TestCase
             'price' => 10023,
             'duration_year' => 1,
             'link' => null,
+            'parent_sku' => 'my_sku',
             'parent_name' => 'my parent name',
             'parent_price' => 1410,
             'files' => []
         ];
-        $insuranceProduct = new InsuranceProduct($insuranceContract, 'my parent name', 14.10);
+        $insuranceProduct = new InsuranceProduct($insuranceContract,'my_sku', 'my parent name', 14.10);
         $this->assertEquals($expectedReturn, $insuranceProduct->toArray());
     }
 
@@ -35,7 +35,7 @@ class InsuranceProductTest extends TestCase
         $name = 'insurance test';
         $insuranceContract = $this->contractFactory($id, $name);
 
-        $insuranceProduct = new InsuranceProduct($insuranceContract, 'my parent name', 14.20);
+        $insuranceProduct = new InsuranceProduct($insuranceContract,'my_sku', 'my parent name', 14.20);
 
         $this->assertEquals(100.23, $insuranceProduct->getFloatPrice());
         $this->assertEquals(1420, $insuranceProduct->getParentPrice());


### PR DESCRIPTION
### Reason for change

<!-- Describe here the reason for change, and provide a link to the corresponding Linear task or Sentry issue. -->

https://linear.app/almapay/issue/ECOM-1808/[🧩-ac]-fix-qty-flow-with-double-popup

### Code changes

Add parent_sku in quoteItem alma_insurance Data and subscribe insurance with insurance product 

<!-- Describe here the code changes at a high level. Anything that can help reviewers review your PR. -->

### How to test

Make an order with 3 product and 2 insurance, invoice it and check in neat portal if you have only 2 insurance

_As a reviewer, you are encouraged to test the PR locally._

<!-- Describe here how to test your changes, if applicable. Insert UI screenshots when relevant -->

### Checklist for authors and reviewers

<!-- Move to the next section the non applicable items -->

- [X] The title of the PR uses business wording, not technical jargon, for the changelog readers to understand it
- [X] The PR implements the changes asked in the referenced task / issue
- [X] The automated tests are compliant with the [testing strategy](https://www.notion.so/almapay/Backend-testing-strategy-06c642cec1bf47b9b8feca3a91ea8d4a)
- [X] The tests are relevant, and cover the corner/error cases, not only the happy path
- [X] You understand the impact of this PR on existing code/features
- [X] The changes include adequate logging and Datadog traces

### Non applicable
- [ ] Documentation is updated (API, developer documentation, ADR, Notion...)

<!-- Move here non applicable items of the checklist, if any -->
