### PR TITLE
Feature/ecom 1844 ac create insurance product on conf save

### DIFF
--- a/Model/Adminhtml/Config/Insurance/ConfigurationSave.php
+++ b/Model/Adminhtml/Config/Insurance/ConfigurationSave.php
@@ -1,0 +1,71 @@
+<?php
+
+namespace Alma\MonthlyPayments\Model\Adminhtml\Config\Insurance;
+
+use Alma\MonthlyPayments\Helpers\InsuranceHelper;
+use Alma\MonthlyPayments\Helpers\InsuranceProductHelper;
+use Alma\MonthlyPayments\Helpers\Logger;
+use Alma\MonthlyPayments\Model\Exceptions\AlmaInsuranceProductException;
+use Magento\Catalog\Api\ProductRepositoryInterface;
+use Magento\Framework\App\Cache\TypeListInterface;
+use Magento\Framework\App\Config\ScopeConfigInterface;
+use Magento\Framework\App\Config\Value;
+use Magento\Framework\Data\Collection\AbstractDb;
+use Magento\Framework\Exception\NoSuchEntityException;
+use Magento\Framework\Model\Context;
+use Magento\Framework\Model\ResourceModel\AbstractResource;
+use Magento\Framework\Registry;
+
+class ConfigurationSave extends Value
+{
+    /**
+     * @var Logger
+     */
+    private $logger;
+    private $productRepository;
+    private $insuranceProductHelper;
+
+    public function __construct(
+        Context                    $context,
+        Registry                   $registry,
+        ScopeConfigInterface       $config,
+        TypeListInterface          $cacheTypeList,
+        Logger                     $logger,
+        ProductRepositoryInterface $productRepository,
+        InsuranceProductHelper     $insuranceProductHelper,
+        AbstractResource           $resource = null,
+        AbstractDb                 $resourceCollection = null,
+        array                      $data = []
+    ) {
+        parent::__construct($context, $registry, $config, $cacheTypeList, $resource, $resourceCollection, $data);
+        $this->logger = $logger;
+        $this->productRepository = $productRepository;
+        $this->insuranceProductHelper = $insuranceProductHelper;
+    }
+
+    /**
+     * @throws AlmaInsuranceProductException
+     * @return $this
+     */
+    public function beforeSave(): ConfigurationSave
+    {
+        $arrayValue = json_decode($this->getValue(), true);
+        if (
+            !$this->isValueChanged() ||
+            !isset($arrayValue['isInsuranceActivated']) ||
+            $arrayValue['isInsuranceActivated'] === false
+        ) {
+            return $this;
+        }
+
+        try {
+            $this->productRepository->get(InsuranceHelper::ALMA_INSURANCE_SKU);
+            return $this;
+        } catch (NoSuchEntityException $e) {
+            $this->logger->info('Insurance product not found, creating it');
+        }
+
+        $this->insuranceProductHelper->createInsuranceProduct();
+        return $this;
+    }
+}

--- a/Test/Unit/Helpers/InsuranceHelperTest.php
+++ b/Test/Unit/Helpers/InsuranceHelperTest.php
@@ -106,7 +106,7 @@ class InsuranceHelperTest extends TestCase
         $this->dbSubscriptionFactory->method('create')->willReturn($subscriptionMock);
         $this->storeManagerInterface = $this->createMock(StoreManager::class);
         $store = $this->createMock(Store::class);
-        $store->method('getBaseUrl')->willReturn('https://my-website.com');
+        $store->method('getBaseUrl')->willReturn('https://my-website.com/');
         $this->storeManagerInterface->method('getStore')->willReturn($store);
 
         $this->insuranceHelper = $this->createNewInsuranceHelper();

--- a/Test/Unit/Model/Adminhtml/Config/Insurance/ConfigurationSaveTest.php
+++ b/Test/Unit/Model/Adminhtml/Config/Insurance/ConfigurationSaveTest.php
@@ -1,0 +1,108 @@
+<?php
+
+namespace Alma\MonthlyPayments\Test\Unit\Model\Adminhtml\Config\Insurance;
+
+use Alma\MonthlyPayments\Helpers\InsuranceProductHelper;
+use Alma\MonthlyPayments\Helpers\Logger;
+use Alma\MonthlyPayments\Model\Adminhtml\Config\Insurance\ConfigurationSave;
+use Alma\MonthlyPayments\Model\Exceptions\AlmaInsuranceProductException;
+use Magento\Catalog\Api\ProductRepositoryInterface;
+use Magento\Framework\App\Cache\TypeListInterface;
+use Magento\Framework\App\Config\ScopeConfigInterface;
+use Magento\Framework\Exception\NoSuchEntityException;
+use Magento\Framework\Model\Context;
+use Magento\Framework\Registry;
+use PHPUnit\Framework\TestCase;
+
+class ConfigurationSaveTest extends TestCase
+{
+    private $context;
+    private $registry;
+    private $config;
+    private $cacheTypeList;
+    private $logger;
+    private $productRepository;
+    private $insuranceProductHelper;
+    private $configurationSave;
+
+    protected function setUp(): void
+    {
+        $this->context = $this->createMock(Context::class);
+        $this->registry = $this->createMock(Registry::class);
+        $this->config = $this->createMock(ScopeConfigInterface::class);
+        $this->cacheTypeList = $this->createMock(TypeListInterface::class);
+        $this->logger = $this->createMock(Logger::class);
+        $this->productRepository = $this->createMock(ProductRepositoryInterface::class);
+        $this->insuranceProductHelper = $this->createMock(InsuranceProductHelper::class);
+        $this->configurationSave = new ConfigurationSave(
+            $this->context,
+            $this->registry,
+            $this->config,
+            $this->cacheTypeList,
+            $this->logger,
+            $this->productRepository,
+            $this->insuranceProductHelper
+        );
+    }
+
+    public function testNoChangeDirectReturn(): void
+    {
+        $this->configurationSave->setValue($this->configFactory());
+        $this->config->method('getValue')->willReturn($this->configFactory());
+        $this->assertEquals($this->configurationSave, $this->configurationSave->beforeSave());
+    }
+    public function testisInsuranceActivatedNotExistInGetValueDirectReturn()
+    {
+        $this->configurationSave->setValue('{"active":true}');
+        $this->config->method('getValue')->willReturn($this->configFactory());
+        $this->assertEquals($this->configurationSave, $this->configurationSave->beforeSave());
+    }
+
+    public function testIfInsuranceNotActivatedDirectReturn(): void
+    {
+        $this->configurationSave->setValue($this->configFactory());
+        $this->config->method('getValue')->willReturn($this->configFactory('true'));
+        $this->assertEquals($this->configurationSave, $this->configurationSave->beforeSave());
+    }
+
+    public function testInsuranceProductAlreadyExistDirectReturn(): void
+    {
+        $this->configurationSave->setValue($this->configFactory('true'));
+        $this->config->method('getValue')->willReturn($this->configFactory());
+        $this->productRepository->method('get')->willReturn($this->createMock(ProductRepositoryInterface::class));
+        $this->assertEquals($this->configurationSave, $this->configurationSave->beforeSave());
+    }
+
+    public function testInsuranceProductNotExistCreateInsuranceProductOk(): void
+    {
+        $this->configurationSave->setValue($this->configFactory('true'));
+        $this->config->method('getValue')->willReturn($this->configFactory());
+        $this->productRepository->method('get')->willThrowException(new NoSuchEntityException());
+        $this->insuranceProductHelper->expects($this->once())->method('createInsuranceProduct');
+        $this->assertEquals($this->configurationSave, $this->configurationSave->beforeSave());
+    }
+
+    public function testInsuranceProductNotExistCreateInsuranceProductThrowAnError(): void
+    {
+        $this->configurationSave->setValue($this->configFactory('true'));
+        $this->config->method('getValue')->willReturn($this->configFactory());
+        $this->productRepository->method('get')->willThrowException(new NoSuchEntityException());
+        $this->insuranceProductHelper->expects($this->once())->method('createInsuranceProduct')->willThrowException(new AlmaInsuranceProductException('Impossible to create insurance product'));
+        $this->expectException(AlmaInsuranceProductException::class);
+        $this->expectExceptionMessage('Impossible to create insurance product');
+        $this->configurationSave->beforeSave();
+    }
+
+    private function configFactory(
+        $isInsuranceActivated = 'false',
+        $isInsuranceOnProductPageActivated = 'false',
+        $isAddToCartPopupActivated = 'false',
+        $isInCartWidgetActivated = 'false'
+    ): string {
+        return '{"isInsuranceActivated":' . $isInsuranceActivated .
+            ',"isInsuranceOnProductPageActivated":' . $isInsuranceOnProductPageActivated .
+            ',"isAddToCartPopupActivated":' . $isAddToCartPopupActivated .
+            ',"isInCartWidgetActivated":' . $isInCartWidgetActivated .
+            '}';
+    }
+}

--- a/etc/adminhtml/system.xml
+++ b/etc/adminhtml/system.xml
@@ -373,6 +373,7 @@
                     <config_path>payment/alma_monthly_payments/insurance_config</config_path>
                     <label>Alma Insurance</label>
                     <frontend_model>Alma\MonthlyPayments\Block\Adminhtml\Form\Field\InsuranceWidget</frontend_model>
+                    <backend_model>Alma\MonthlyPayments\Model\Adminhtml\Config\Insurance\ConfigurationSave</backend_model>
                 </field>
             </group>
         </section>


### PR DESCRIPTION
### Reason for change

<!-- Describe here the reason for change, and provide a link to the corresponding Linear task or Sentry issue. -->

https://linear.app/almapay/issue/ECOM-1844/[🧩-ac]-create-insurance-product-on-conf-save

### Code changes

Create a new backend model for insurance config field who create insurance product if not exist on save

<!-- Describe here the code changes at a high level. Anything that can help reviewers review your PR. -->

### How to test

Install module, check if insurance product exist ( no ) 
add a Key, product not exist 
save insurance config without change, product not exist,
Activate insurance , product exist 

_As a reviewer, you are encouraged to test the PR locally._

<!-- Describe here how to test your changes, if applicable. Insert UI screenshots when relevant -->

### Checklist for authors and reviewers

<!-- Move to the next section the non applicable items -->

- [X] The title of the PR uses business wording, not technical jargon, for the changelog readers to understand it
- [X] The PR implements the changes asked in the referenced task / issue
- [X] The automated tests are compliant with the [testing strategy](https://www.notion.so/almapay/Backend-testing-strategy-06c642cec1bf47b9b8feca3a91ea8d4a)
- [X] The tests are relevant, and cover the corner/error cases, not only the happy path
- [X] You understand the impact of this PR on existing code/features
- [X] The changes include adequate logging and Datadog traces
- [] Documentation is updated (API, developer documentation, ADR, Notion...)

### Non applicable

<!-- Move here non applicable items of the checklist, if any -->
