### PR TITLE
[DEVX] Ensure release-drafter is based on develop and the release points to main

### DIFF
--- a/.github/workflows/release-publish.yml
+++ b/.github/workflows/release-publish.yml
@@ -87,6 +87,8 @@ jobs:
       - name: Publish Github release
         uses: actions/github-script@v7
         with:
+          # target_commitish is set to refs/heads/develop by release-drafter as we need to retrieve pull requests merged into develop
+          # We need to override it to refs/heads/main to point to the last commit of main branch instead of develop branch
           script: |
             const { owner, repo } = context.repo;
             await github.rest.repos.updateRelease({
@@ -95,7 +97,8 @@ jobs:
               release_id: "${{ steps.fetch-release-draft.outputs.id }}",
               draft: false,
               make_latest: true,
-              tag_name: "${{ steps.fetch-release-draft.outputs.name }}"
+              tag_name: "${{ steps.fetch-release-draft.outputs.name }}",
+              target_commitish: "refs/heads/main"
             });
 
       - name: Format release notes for Slack

--- a/.github/workflows/release-pull-request.yml
+++ b/.github/workflows/release-pull-request.yml
@@ -26,6 +26,11 @@ jobs:
       - name: Create release draft
         uses: release-drafter/release-drafter@v6
         id: release-drafter
+        with:
+          # release-drafter should be based on develop to get the correct content as pull requests are merged into develop
+          # Note that the target commitish of the release should be updated to refs/heads/main when published
+          # (Otherwise the tag will point to the last commit on develop branch instead of the last commit of main branch)
+          commitish: refs/heads/develop
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 


### PR DESCRIPTION
### Reason for change

Release drafter content was not accurate when `release-pull-request` workflow was running from main
During last release it was fixed by triggering the workflow from develop, but we ended with a tag pointing to the last commit from develop branch, instead of the last commit from main branch. 
It was therefore missing the change of version in the `composer.json`, and thus the v5.0.0 was ignored by packagist.

### Code changes

<!-- Describe here the code changes at a high level. Anything that can help reviewers review your PR. -->
* We ensure release-drafter is based on develop, no matter on which branch the workflow is running
* We ensure the release will point to the last commit from main when published
