### PR TITLE
Fix add insurance pop up click event listener only for eligible products

### DIFF
--- a/view/frontend/templates/catalog/product/insurance.phtml
+++ b/view/frontend/templates/catalog/product/insurance.phtml
@@ -10,8 +10,6 @@
     <input type="hidden" name="alma_insurance_id" form="product_addtocart_form" value="">
     <input type="hidden" name="alma_insurance_qty" form="product_addtocart_form" value="">
     <div id="alma-insurance-modal"></div>
-<?php } ?>
-<?php if ($widgetIsActivated) { ?>
     <script>
         require([
             'jquery',
@@ -38,6 +36,20 @@
             var isAddToCartFlow = false;
             var selectedAlmaInsurance = null
             window.addEventListener('message', (e) => {
+                if(e.data.type === 'almaEligibilityAnswer'){
+                    <?php if ($popupIsActivated) { ?>
+                    if (e.data?.eligibilityCallResponseStatus?.response?.eligibleProduct){
+                        document.getElementById('product-addtocart-button').addEventListener('click', function (e) {
+                            if (!madeChoiceForInsurance){
+                                e.preventDefault();
+                                openModal('popupModal', parseInt(document.getElementById('qty').value));
+                                madeChoiceForInsurance = true;
+                                isAddToCartFlow = true;
+                            }
+                        })
+                    }
+                    <?php } ?>
+                }
                 if(e.data.type === 'getResetInsuranceData'){
                     $('input[name=alma_insurance_id]').val('');
                     $('input[name=alma_insurance_qty]').val('')
@@ -78,16 +90,6 @@
                 }
             });
 
-            <?php if ($popupIsActivated) { ?>
-            document.getElementById('product-addtocart-button').addEventListener('click', function (e) {
-                if (!madeChoiceForInsurance){
-                    e.preventDefault();
-                    openModal('popupModal', parseInt(document.getElementById('qty').value));
-                    madeChoiceForInsurance = true;
-                    isAddToCartFlow = true;
-                }
-            })
-            <?php } ?>
         });
     </script>
 <?php } ?>


### PR DESCRIPTION
### Reason for change

Fix add insurance pop up click event listener only for eligible products

[[Linear task](https://linear.app/almapay/issue/ECOM-xxx/)
](https://linear.app/almapay/issue/ECOM-1862/[ac]-fix-add-pop-up-click-event-listener-only-for-eligible-product)
### Code changes

<!-- Describe here the code changes at a high level. Anything that can help reviewers review your PR. -->

### How to test

_As a reviewer, you are encouraged to test the PR locally._

Test add to cart button for an eligible and not eligible product 

