### PR TITLE
[DEVX] Exclude release PRs from the changelog

### DIFF
--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -21,6 +21,7 @@ categories:
 
 exclude-labels:
   - 'skip-changelog'
+  - 'release'
   - 'type: chore'
   - 'type: ci'
   - 'type: refactor'


### PR DESCRIPTION
### Reason for change

<!-- Describe here the reason for change, and provide a link to the corresponding Linear task or Sentry issue. -->
We want to ensure that release PRs won't appear in the changelog generated for next release

### Note

Change is pushed on main as it's always the default branch that is taken into account for the release-drafter template