### PR TITLE
Fix issue when creating quote via api

### DIFF
--- a/Helpers/QuoteHelper.php
+++ b/Helpers/QuoteHelper.php
@@ -153,8 +153,9 @@ class QuoteHelper
     private function getQuoteByContextUserId():?CartInterface
     {
         $quote = null;
+        $userType = $this->getUserType();
         $customerUserId = $this->getContextUserId();
-        if ($customerUserId > 0) {
+        if ($userType != 1 && $customerUserId > 0) {
             $quote = $this->quoteRepository->getActiveForCustomer($customerUserId);
         }
         return $quote;
@@ -173,6 +174,15 @@ class QuoteHelper
             $this->logger->info('getQuoteById Exception : ', [$e->getMessage()]);
         }
         return $quote;
+    }
+
+    /**
+     * @return int|null
+     * default value 0
+     */
+    private function getUserType():?int
+    {
+        return $this->userContext->getUserType();
     }
 
     /**


### PR DESCRIPTION
### Reason for change

When we are trying to create a quote using the Magento API we have the following error

`{
    "message": "No such entity with %fieldName = %fieldValue",
    "parameters": {
        "fieldName": "customerId",
        "fieldValue": 3
    },`


### Code changes

Included a validation to not load quote by customer integration ids.

### How to test

Create a new quote using following API Methods:

1. rest/all/V1/carts/
2. rest/all/V1/carts/{cart_id}/items
3. rest/all/V1/carts/{cart_id}/estimate-shipping-methods
4. rest/all/V1/carts/{cart_id}/shipping-information (This one fails)


### Checklist for authors and reviewers


- [X] The title of the PR uses business wording, not technical jargon, for the changelog readers to understand it
- [X] The PR implements the changes asked in the referenced task / issue
- [] The automated tests are compliant with the [testing strategy](https://www.notion.so/almapay/Backend-testing-strategy-06c642cec1bf47b9b8feca3a91ea8d4a)
- [ ] The tests are relevant, and cover the corner/error cases, not only the happy path
- [X] You understand the impact of this PR on existing code/features
- [ ] The changes include adequate logging and Datadog traces
- [ ] Documentation is updated (API, developer documentation, ADR, Notion...)
