### PR TITLE
Fix issue The order confirmation email was sent, but the field email_sent remains NULL 

### DIFF
--- a/Helpers/PaymentValidation.php
+++ b/Helpers/PaymentValidation.php
@@ -265,7 +265,6 @@ class PaymentValidation
         $payment = $order->getPayment();
         $this->addTransactionToPayment($payment, $order, $almaPayment);
         $this->paymentProcessor->registerCaptureNotification($payment, $payment->getBaseAmountAuthorized());
-        $this->orderHelper->notify($order->getId());
 
         // TODO : Paylater / PnX
         $order = $this->addCommentToOrder($order, __('First instalment captured successfully'), $newStatus);
@@ -275,6 +274,8 @@ class PaymentValidation
         }
         $this->orderHelper->save($order);
         $this->inactiveQuoteById($order->getQuoteId());
+
+        $this->orderHelper->notify($order->getId());
     }
 
     /**


### PR DESCRIPTION
### Reason for change

 [issue-192](https://github.com/alma/alma-monthlypayments-magento2/issues/192) The order confirmation email was sent, but the field email_sent remains NULL 

### Code changes

Save order before sending order confirmation email

![Screenshot from 2024-09-06 16-04-20](https://github.com/user-attachments/assets/820516c4-ac97-4b7e-9e7f-6634400d99e4)


### How to test

Place an order using the Alma payment method


