### PR TITLE
Remove insurance products from active carts when insurance is disabled

### DIFF
--- a/Helpers/InsuranceProductHelper.php
+++ b/Helpers/InsuranceProductHelper.php
@@ -3,7 +3,8 @@
 namespace Alma\MonthlyPayments\Helpers;
 
 use Alma\MonthlyPayments\Model\Exceptions\AlmaInsuranceProductException;
-use Magento\Catalog\Model\Product;
+use Alma\MonthlyPayments\Model\Exceptions\AlmaProductException;
+use Magento\Catalog\Api\Data\ProductInterface;
 use Magento\Catalog\Model\Product\Attribute\Source\Status;
 use Magento\Catalog\Model\Product\Visibility;
 use Magento\Catalog\Model\ProductFactory;
@@ -12,18 +13,41 @@ use Magento\Framework\App\Filesystem\DirectoryList;
 use Magento\Framework\App\Helper\AbstractHelper;
 use Magento\Framework\App\Helper\Context;
 use Magento\Framework\Exception\LocalizedException;
+use Magento\Framework\Exception\NoSuchEntityException;
 use Magento\Framework\Filesystem;
 use Magento\Framework\Filesystem\Io\File;
 use Magento\Framework\Module\Dir;
 
 class InsuranceProductHelper extends AbstractHelper
 {
+    /**
+     * @var ProductFactory
+     */
     private $productFactory;
+    /**
+     * @var File
+     */
     private $fileProcessor;
+    /**
+     * @var Filesystem
+     */
     private $filesystem;
+    /**
+     * @var Logger
+     */
     private $logger;
+    /**
+     * @var Dir
+     */
     private $directory;
+    /**
+     * @var ProductRepository
+     */
     private $productRepository;
+    /**
+     * @var ProductHelper
+     */
+    private $productHelper;
 
     /**
      * @param Context $context
@@ -33,6 +57,7 @@ class InsuranceProductHelper extends AbstractHelper
      * @param File $fileProcessor
      * @param Filesystem $filesystem
      * @param ProductRepository $productRepository
+     * @param ProductHelper $productHelper
      */
     public function __construct(
         Context           $context,
@@ -41,10 +66,9 @@ class InsuranceProductHelper extends AbstractHelper
         Dir               $directory,
         File              $fileProcessor,
         Filesystem        $filesystem,
-        ProductRepository $productRepository
-
+        ProductRepository $productRepository,
+        ProductHelper     $productHelper
     ) {
-
         parent::__construct($context);
         $this->productFactory = $productFactory;
         $this->fileProcessor = $fileProcessor;
@@ -52,15 +76,55 @@ class InsuranceProductHelper extends AbstractHelper
         $this->logger = $logger;
         $this->directory = $directory;
         $this->productRepository = $productRepository;
+        $this->productHelper = $productHelper;
     }
 
     /**
+     * Get insurance product
+     *
+     * @return ProductInterface
+     * @throws NoSuchEntityException
+     */
+    public function getInsuranceProduct(): ProductInterface
+    {
+        return $this->productRepository->get(InsuranceHelper::ALMA_INSURANCE_SKU);
+    }
+
+    /**
+     * Disable insurance product if exist
+     *
+     * @return void
+     * @throws AlmaInsuranceProductException
+     */
+    public function disableInsuranceProductIfExist(): void
+    {
+        try {
+            $insuranceProduct = $this->getInsuranceProduct();
+        } catch (NoSuchEntityException $e) {
+            $this->logger->info('Alma insurance product not found no disable needed', [$e->getMessage()]);
+            return;
+        }
+
+        if ($insuranceProduct->getStatus() === Status::STATUS_DISABLED) {
+            return;
+        }
+
+        try {
+            $this->productHelper->disableProduct($insuranceProduct);
+        } catch (AlmaProductException $e) {
+            $this->logger->error('Disable insurance product failed with message : ', [$e->getMessage()]);
+            throw new AlmaInsuranceProductException($e->getMessage(), $e->getCode(), $e);
+        }
+    }
+
+    /**
+     * Create Insurance product in merchant catalogue
+     *
      * @return void
      */
     public function createInsuranceProduct(): void
     {
         // Create a new product with the insurance SKU
-        /** @var Product $insuranceProduct */
         $insuranceProduct = $this->productFactory->create();
         $insuranceProduct->setSku(InsuranceHelper::ALMA_INSURANCE_SKU);
         $insuranceProduct->setName('Alma Insurance');
@@ -75,11 +139,11 @@ class InsuranceProductHelper extends AbstractHelper
             "manage_stock" => 0,
             "use_config_notify_stock_qty" => 0
         ]);
-        // Not visible individualy ID 1
+        // Not visible individually ID 1
         $insuranceProduct->setVisibility(Visibility::VISIBILITY_NOT_VISIBLE);
-        // ID de la classe de taxe (0 pour non applicable)
+        // Tax class ID 0 for not applicable
         $insuranceProduct->setTaxClassId(0);
-        $insuranceProduct->setDescription('Alma Insurance product');
+        $insuranceProduct->setDescription('Alma Insura      nce product');
         $insuranceProduct->setUrlKey('alma-insurance');
 
         $fileName = 'alma_insurance_logo.jpg';

--- a/Helpers/InsuranceProductHelper.php
+++ b/Helpers/InsuranceProductHelper.php
@@ -166,7 +166,7 @@ class InsuranceProductHelper extends AbstractHelper
         $insuranceProduct->setVisibility(Visibility::VISIBILITY_NOT_VISIBLE);
         // Tax class ID 0 for not applicable
         $insuranceProduct->setTaxClassId(0);
-        $insuranceProduct->setDescription('Alma Insura      nce product');
+        $insuranceProduct->setDescription('Alma Insurance product');
         $insuranceProduct->setUrlKey('alma-insurance');
 
         $fileName = 'alma_insurance_logo.jpg';
@@ -197,15 +197,5 @@ class InsuranceProductHelper extends AbstractHelper
                 [InsuranceHelper::ALMA_INSURANCE_SKU]
             );
         }
-    }
-
-    /**
-     * Get current store ID
-     *
-     * @return int|null
-     */
-    private function getCurrentStoreId(): ?int
-    {
-        return $this->scopeConfig->getValue('store_id', ScopeInterface::SCOPE_STORE);
     }
 }

--- a/Helpers/InsuranceProductHelper.php
+++ b/Helpers/InsuranceProductHelper.php
@@ -17,6 +17,8 @@ use Magento\Framework\Exception\NoSuchEntityException;
 use Magento\Framework\Filesystem;
 use Magento\Framework\Filesystem\Io\File;
 use Magento\Framework\Module\Dir;
+use Magento\Store\Model\ScopeInterface;
+use Magento\Store\Model\Store;
 
 class InsuranceProductHelper extends AbstractHelper
 {
@@ -87,7 +89,9 @@ class InsuranceProductHelper extends AbstractHelper
      */
     public function getInsuranceProduct(): ProductInterface
     {
-        return $this->productRepository->get(InsuranceHelper::ALMA_INSURANCE_SKU);
+        $this->logger->info('getCurrentStoreId', [$this->getCurrentStoreId()]);
+
+        return $this->productRepository->get(InsuranceHelper::ALMA_INSURANCE_SKU, true, Store::DEFAULT_STORE_ID);
     }
 
     /**
@@ -105,7 +109,7 @@ class InsuranceProductHelper extends AbstractHelper
             return;
         }
 
-        if ($insuranceProduct->getStatus() === Status::STATUS_DISABLED) {
+        if ((int)$insuranceProduct->getStatus() === Status::STATUS_DISABLED) {
             return;
         }
 
@@ -174,5 +178,15 @@ class InsuranceProductHelper extends AbstractHelper
                 [InsuranceHelper::ALMA_INSURANCE_SKU]
             );
         }
+    }
+
+    /**
+     * Get current store ID
+     *
+     * @return int
+     */
+    private function getCurrentStoreId(): int
+    {
+        return $this->scopeConfig->getValue('store_id', ScopeInterface::SCOPE_STORE);
     }
 }

--- a/Helpers/ProductHelper.php
+++ b/Helpers/ProductHelper.php
@@ -119,4 +119,26 @@ class ProductHelper
             throw new AlmaProductException($e->getMessage(), $e->getCode(), $e);
         }
     }
+
+    /**
+     * Enable a product
+     *
+     * @param Product $product
+     * @return void
+     * @throws AlmaProductException
+     */
+    public function enableProduct(ProductInterface $product): void
+    {
+        $product->setStatus(Status::STATUS_ENABLED);
+        try {
+            $this->productRepository->save($product);
+
+        } catch (CouldNotSaveException|InputException|StateException $e) {
+            $this->logger->warning(
+                "Impossible to enable Product",
+                ['productId' => $product->getId(), 'message' => $e->getMessage()]
+            );
+            throw new AlmaProductException($e->getMessage(), $e->getCode(), $e);
+        }
+    }
 }

--- a/Helpers/ProductHelper.php
+++ b/Helpers/ProductHelper.php
@@ -2,11 +2,19 @@
 
 namespace Alma\MonthlyPayments\Helpers;
 
+use Alma\MonthlyPayments\Model\Exceptions\AlmaProductException;
+use Magento\Catalog\Api\Data\ProductInterface;
 use Magento\Catalog\Model\Product;
+use Magento\Catalog\Model\Product\Attribute\Source\Status;
+use Magento\Catalog\Model\ProductRepository;
 use Magento\Catalog\Model\ResourceModel\Category\Collection as CategoryCollection;
 use Magento\Catalog\Model\ResourceModel\Category\CollectionFactory as CategoryCollectionFactory;
 use Magento\Catalog\Model\ResourceModel\Product\Collection;
 use Magento\Catalog\Model\ResourceModel\Product\CollectionFactory;
+use Magento\Framework\Exception\CouldNotSaveException;
+use Magento\Framework\Exception\InputException;
+use Magento\Framework\Exception\LocalizedException;
+use Magento\Framework\Exception\StateException;
 
 class ProductHelper
 {
@@ -22,20 +30,27 @@ class ProductHelper
      * @var CategoryCollection
      */
     private $categoryCollectionFactory;
+    /**
+     * @var ProductRepository
+     */
+    private $productRepository;
 
     /**
      * @param Logger $logger
      * @param CollectionFactory $productCollectionFactory
      * @param CategoryCollectionFactory $categoryCollectionFactory
+     * @param ProductRepository $productRepository
      */
     public function __construct(
-        Logger             $logger,
-        CollectionFactory  $productCollectionFactory,
-        CategoryCollectionFactory $categoryCollectionFactory
+        Logger                    $logger,
+        CollectionFactory         $productCollectionFactory,
+        CategoryCollectionFactory $categoryCollectionFactory,
+        ProductRepository         $productRepository
     ) {
         $this->productCollectionFactory = $productCollectionFactory;
         $this->logger = $logger;
         $this->categoryCollectionFactory = $categoryCollectionFactory;
+        $this->productRepository = $productRepository;
     }
 
     /**
@@ -49,7 +64,7 @@ class ProductHelper
         /** @var Collection $collection */
         $collection = $this->productCollectionFactory->create();
         $collection->addAttributeToSelect('*');
-        return $collection->addAttributeToFilter('entity_id', ['in'=>$productIds]);
+        return $collection->addAttributeToFilter('entity_id', ['in' => $productIds]);
     }
 
     /**
@@ -68,16 +83,40 @@ class ProductHelper
 
         return array_values($categoriesId);
     }
+
     /**
      * Generate categories collection with product a collection
      *
      * @param Collection $products
      * @return CategoryCollection
+     * @throws LocalizedException
      */
     public function getProductsCategories(Collection $products): CategoryCollection
     {
         $categoriesId = $this->getProductsCategoriesIds($products);
 
-        return $this->categoryCollectionFactory->create()->addAttributeToSelect('*')->addFieldToFilter('entity_id', ['in'=>$categoriesId]);
+        return $this->categoryCollectionFactory->create()->addAttributeToSelect('*')->addFieldToFilter('entity_id', ['in' => $categoriesId]);
+    }
+
+    /**
+     * Disable a product
+     *
+     * @param Product $product
+     * @return void
+     * @throws AlmaProductException
+     */
+    public function disableProduct(ProductInterface $product): void
+    {
+        $product->setStatus(Status::STATUS_DISABLED);
+        try {
+            $this->productRepository->save($product);
+
+        } catch (CouldNotSaveException|InputException|StateException $e) {
+            $this->logger->warning(
+                "Impossible to disable Product",
+                ['productId' => $product->getId(), 'message' => $e->getMessage()]
+            );
+            throw new AlmaProductException($e->getMessage(), $e->getCode(), $e);
+        }
     }
 }

--- a/Model/Exceptions/AlmaProductException.php
+++ b/Model/Exceptions/AlmaProductException.php
@@ -1,0 +1,8 @@
+<?php
+
+namespace Alma\MonthlyPayments\Model\Exceptions;
+
+class AlmaProductException extends AlmaException
+{
+
+}

--- a/Test/Unit/Helpers/InsuranceProductHelperTest.php
+++ b/Test/Unit/Helpers/InsuranceProductHelperTest.php
@@ -116,6 +116,7 @@ class InsuranceProductHelperTest extends TestCase
         $this->productHelper->expects($this->once())->method('disableProduct')->with($product);
         $this->insuranceProductHelper->disableInsuranceProductIfExist();
     }
+
     public function testDisableInsuranceProductThrowExceptionIfErrorOnSave(): void
     {
         $product = $this->getProductMock();
@@ -128,7 +129,22 @@ class InsuranceProductHelperTest extends TestCase
         $this->insuranceProductHelper->disableInsuranceProductIfExist();
     }
 
-    private function getProductMock(): ProductInterface | MockObject
+    public function testEnableInsuranceProductThrowExceptionIfProductNotExist(): void
+    {
+        $this->productRepository->method('get')->willThrowException(new NoSuchEntityException());
+        $this->expectException(AlmaInsuranceProductException::class);
+        $this->insuranceProductHelper->enableInsuranceProductIfExist();
+    }
+
+    public function testEnableInsuranceProductNotCallEnableProductHelperForExistingProductWithEnableStatus(): void
+    {
+        $product = $this->getProductMock();
+        $product->method('getStatus')->willReturn(Status::STATUS_ENABLED);
+        $this->productHelper->expects($this->never())->method('enableProduct');
+        $this->insuranceProductHelper->enableInsuranceProductIfExist();
+    }
+
+    private function getProductMock(): ProductInterface|MockObject
     {
         $product = $this->createMock(ProductInterface::class);
         $this->productRepository->method('get')->willReturn($product);

--- a/Test/Unit/Helpers/InsuranceProductHelperTest.php
+++ b/Test/Unit/Helpers/InsuranceProductHelperTest.php
@@ -1,0 +1,139 @@
+<?php
+
+namespace Alma\MonthlyPayments\Test\Unit\Helpers;
+
+use Alma\MonthlyPayments\Helpers\InsuranceProductHelper;
+use Alma\MonthlyPayments\Helpers\Logger;
+use Alma\MonthlyPayments\Helpers\ProductHelper;
+use Alma\MonthlyPayments\Model\Exceptions\AlmaInsuranceProductException;
+use Alma\MonthlyPayments\Model\Exceptions\AlmaProductException;
+use Magento\Catalog\Api\Data\ProductInterface;
+use Magento\Catalog\Model\Product\Attribute\Source\Status;
+use Magento\Catalog\Model\ProductFactory;
+use Magento\Catalog\Model\ProductRepository;
+use Magento\Framework\App\Helper\Context;
+use Magento\Framework\Exception\NoSuchEntityException;
+use Magento\Framework\Filesystem;
+use Magento\Framework\Filesystem\Io\File;
+use Magento\Framework\Module\Dir;
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
+
+class InsuranceProductHelperTest extends TestCase
+{
+    /**
+     * @var Context
+     */
+    private $context;
+    /**
+     * @var Logger
+     */
+    private $logger;
+    /**
+     * @var ProductFactory
+     */
+    private $productFactory;
+    /**
+     * @var Dir
+     */
+    private Dir $dir;
+    /**
+     * @var File
+     */
+    private File $file;
+    /**
+     * @var Filesystem
+     */
+    private Filesystem $fileSystem;
+    /**
+     * @var ProductRepository
+     */
+    private $productRepository;
+    /**
+     * @var InsuranceProductHelper
+     */
+    private $insuranceProductHelper;
+    /**
+     * @var ProductHelper
+     */
+    private $productHelper;
+
+    protected function setUp(): void
+    {
+        $this->context = $this->createMock(Context::class);
+        $this->logger = $this->createMock(Logger::class);
+        $this->productFactory = $this->createMock(ProductFactory::class);
+        $this->dir = $this->createMock(Dir::class);
+        $this->file = $this->createMock(File::class);
+        $this->fileSystem = $this->createMock(Filesystem::class);
+        $this->productRepository = $this->createMock(ProductRepository::class);
+        $this->productHelper = $this->createMock(ProductHelper::class);
+        $this->insuranceProductHelper = new InsuranceProductHelper(
+            $this->context,
+            $this->logger,
+            $this->productFactory,
+            $this->dir,
+            $this->file,
+            $this->fileSystem,
+            $this->productRepository,
+            $this->productHelper
+        );
+    }
+
+    public function testGetInsuranceProductThrowExceptionIfNoProductFound(): void
+    {
+        $this->productRepository->method('get')->willThrowException(new NoSuchEntityException());
+        $this->expectException(NoSuchEntityException::class);
+        $this->insuranceProductHelper->getInsuranceProduct();
+    }
+
+    public function testGetInsuranceProductReturnProduct(): void
+    {
+        $this->productRepository->method('get')->willReturn($this->createMock(ProductInterface::class));
+        $this->assertInstanceOf(ProductInterface::class, $this->insuranceProductHelper->getInsuranceProduct());
+    }
+
+    public function testDisableInsuranceProductNotCallDisableProductIfNoProductFound(): void
+    {
+        $this->productRepository->method('get')->willThrowException(new NoSuchEntityException());
+        $this->productHelper->expects($this->never())->method('disableProduct');
+        $this->logger->expects($this->once())->method('info');
+        $this->insuranceProductHelper->disableInsuranceProductIfExist();
+    }
+
+    public function testDisableInsuranceProductNotCallDisableProductIfProductFoundWithDisabledStatus(): void
+    {
+        $product = $this->getProductMock();
+        $product->method('getStatus')->willReturn(Status::STATUS_DISABLED);
+        $this->productHelper->expects($this->never())->method('disableProduct');
+        $this->insuranceProductHelper->disableInsuranceProductIfExist();
+    }
+
+    public function testDisableInsuranceProductCallDisableProductIfProductFoundWithEnabledStatus(): void
+    {
+        $product = $this->getProductMock();
+        $product->method('getStatus')->willReturn(Status::STATUS_ENABLED);
+        $this->productHelper->expects($this->once())->method('disableProduct')->with($product);
+        $this->insuranceProductHelper->disableInsuranceProductIfExist();
+    }
+    public function testDisableInsuranceProductThrowExceptionIfErrorOnSave(): void
+    {
+        $product = $this->getProductMock();
+        $this->productHelper
+            ->expects($this->once())
+            ->method('disableProduct')
+            ->with($product)
+            ->willThrowException(new AlmaProductException('Error on save'));
+        $this->expectException(AlmaInsuranceProductException::class);
+        $this->insuranceProductHelper->disableInsuranceProductIfExist();
+    }
+
+    private function getProductMock(): ProductInterface | MockObject
+    {
+        $product = $this->createMock(ProductInterface::class);
+        $this->productRepository->method('get')->willReturn($product);
+        return $product;
+    }
+
+
+}

--- a/Test/Unit/Helpers/ProductHelperTest.php
+++ b/Test/Unit/Helpers/ProductHelperTest.php
@@ -97,6 +97,28 @@ class ProductHelperTest extends TestCase
         $this->createProductHelper()->disableProduct($product);
     }
 
+    public function testEnableProductCallSetStatusAndNotThrowExceptionForSave(): void
+    {
+        $product = $this->createMock(Product::class);
+        $product->expects($this->once())->method('setStatus')->with(Status::STATUS_ENABLED);
+        $this->productRepository->expects($this->once())->method('save');
+        $this->createProductHelper()->enableProduct($product);
+    }
+    /**
+     * @dataProvider errorDataProvider
+     */
+    public function testEnableProductCallSetStatusAndThrowExceptionForSave($exceptionClass): void
+    {
+        $product = $this->createMock(Product::class);
+        $product->expects($this->once())->method('setStatus')->with(Status::STATUS_ENABLED);
+        $this->productRepository
+            ->expects($this->once())
+            ->method('save')
+            ->willThrowException($exceptionClass);
+        $this->expectException(AlmaProductException::class);
+        $this->createProductHelper()->enableProduct($product);
+    }
+
     private function errorDataProvider(): array
     {
         return [

--- a/Test/Unit/Helpers/ProductHelperTest.php
+++ b/Test/Unit/Helpers/ProductHelperTest.php
@@ -4,10 +4,17 @@ namespace Alma\MonthlyPayments\Test\Unit\Helpers;
 
 use Alma\MonthlyPayments\Helpers\Logger;
 use Alma\MonthlyPayments\Helpers\ProductHelper;
+use Alma\MonthlyPayments\Model\Exceptions\AlmaProductException;
 use Magento\Catalog\Model\Product;
+use Magento\Catalog\Model\Product\Attribute\Source\Status;
+use Magento\Catalog\Model\ProductRepository;
 use Magento\Catalog\Model\ResourceModel\Category\CollectionFactory as CategoryCollectionFactory;
 use Magento\Catalog\Model\ResourceModel\Product\Collection;
 use Magento\Catalog\Model\ResourceModel\Product\CollectionFactory;
+use Magento\Framework\Exception\CouldNotSaveException;
+use Magento\Framework\Exception\InputException;
+use Magento\Framework\Exception\StateException;
+use Magento\Framework\Phrase;
 use PHPUnit\Framework\TestCase;
 
 class ProductHelperTest extends TestCase
@@ -24,12 +31,17 @@ class ProductHelperTest extends TestCase
      * @var CategoryCollectionFactory
      */
     private $categoryCollection;
+    /**
+     * @var ProductRepository
+     */
+    private $productRepository;
 
     public function setUp(): void
     {
         $this->logger = $this->createMock(Logger::class);
         $this->productCollectionFactory = $this->createMock(CollectionFactory::class);
         $this->categoryCollection = $this->createMock(CategoryCollectionFactory::class);
+        $this->productRepository = $this->createMock(ProductRepository::class);
     }
 
     private function createProductHelper(): ProductHelper
@@ -42,7 +54,8 @@ class ProductHelperTest extends TestCase
         return [
             $this->logger,
             $this->productCollectionFactory,
-            $this->categoryCollection
+            $this->categoryCollection,
+            $this->productRepository
         ];
     }
 
@@ -59,5 +72,37 @@ class ProductHelperTest extends TestCase
         $productCollectionMock->method('getIterator')->willReturn($iterator);
         $result = $this->createProductHelper()->getProductsCategoriesIds($productCollectionMock);
         $this->assertEquals(["2", "3", "5"], $result);
+    }
+
+    public function testDisableProductCallSetStatusAndNotThrowExceptionForSave(): void
+    {
+        $product = $this->createMock(Product::class);
+        $product->expects($this->once())->method('setStatus')->with(Status::STATUS_DISABLED);
+        $this->productRepository->expects($this->once())->method('save');
+        $this->createProductHelper()->disableProduct($product);
+    }
+
+    /**
+     * @dataProvider errorDataProvider
+     */
+    public function testDisableProductCallSetStatusAndThrowExceptionForSave($exceptionClass): void
+    {
+        $product = $this->createMock(Product::class);
+        $product->expects($this->once())->method('setStatus')->with(Status::STATUS_DISABLED);
+        $this->productRepository
+            ->expects($this->once())
+            ->method('save')
+            ->willThrowException($exceptionClass);
+        $this->expectException(AlmaProductException::class);
+        $this->createProductHelper()->disableProduct($product);
+    }
+
+    private function errorDataProvider(): array
+    {
+        return [
+            'Could not save Exception' => [new CouldNotSaveException(new Phrase('Error could not save'))],
+            'Input Exception' => [new InputException(new Phrase('Error input exception'))],
+            'State Exception' => [new StateException(new Phrase('Error state exception'))],
+        ];
     }
 }

--- a/Test/Unit/Observer/ShipmentTrackObserverTest.php
+++ b/Test/Unit/Observer/ShipmentTrackObserverTest.php
@@ -64,6 +64,10 @@ class ShipmentTrackObserverTest extends TestCase
      * @var OrderInterface
      */
     private $trackOrder;
+    /**
+     * @var ShipmentTrackObserver
+     */
+    private $shipmentTrackObserver;
 
 
     protected function setUp(): void
@@ -374,7 +378,7 @@ class ShipmentTrackObserverTest extends TestCase
             $this->almaClient,
             $this->logger
         );
-        $this->assertNull($this->shipmentTrackObserver->execute($this->observer));
+        $this->shipmentTrackObserver->execute($this->observer);
     }
 
     /**


### PR DESCRIPTION
### Reason for change

Disable Alma insurance product to remove it from active cart and delete insurance data in quote_item DB
Enable Alma insurance product when insurance is activated

<!-- Describe here the reason for change, and provide a link to the corresponding Linear task or Sentry issue. -->

[Linear task](https://linear.app/almapay/issue/ECOM-2038/ac-remove-insurance-in-cart-when-deactivated)

### Code changes

Trigger enable and disable/delete data at config save

<!-- Describe here the code changes at a high level. Anything that can help reviewers review your PR. -->

### How to test

Create a quote with an insurance. 
Disable insurance and check product in BO
Check Cart and minicart.
Enable insurance and check product in BO

_As a reviewer, you are encouraged to test the PR locally._

<!-- Describe here how to test your changes, if applicable. Insert UI screenshots when relevant -->

### Checklist for authors and reviewers

<!-- Move to the next section the non applicable items -->

- [ ] The title of the PR uses business wording, not technical jargon, for the changelog readers to understand it
- [ ] The PR implements the changes asked in the referenced task / issue
- [ ] The automated tests are compliant with the [testing strategy](https://www.notion.so/almapay/Backend-testing-strategy-06c642cec1bf47b9b8feca3a91ea8d4a)
- [ ] The tests are relevant, and cover the corner/error cases, not only the happy path
- [ ] You understand the impact of this PR on existing code/features
- [ ] The changes include adequate logging and Datadog traces
- [ ] Documentation is updated (API, developer documentation, ADR, Notion...)

### Non applicable

<!-- Move here non applicable items of the checklist, if any -->
