### PR TITLE
[DEX-697] Run unit tests and lint in separate jobs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,9 +11,10 @@ on:
       - main
 
 jobs:
-  ci:
-    name: Lint and tests
-    runs-on: ubuntu-22.04
+
+  lint:
+    name: Lint code
+    runs-on: ubuntu-24.04
 
     steps:
       - name: Checkout repository
@@ -37,6 +38,22 @@ jobs:
 
       - name: Lint
         run: task lint
+
+  test:
+    name: Run tests
+    runs-on: ubuntu-24.04
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          persist-credentials: false
+
+      - name: Install taskfile.dev
+        uses: arduino/setup-task@v2
+        with:
+          version: 3.x
+          repo-token: ${{ github.token }}
 
       - name: Run PHPUnit tests with coverage
         run: task test

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,6 +3,9 @@ ARG PHP_VERSION=8.1
 FROM composer:2 as composer
 FROM php:${PHP_VERSION}-fpm
 
+ARG UID
+ARG GID
+
 # Install dependencies
 RUN apt update && \
     apt install -y --no-install-recommends \
@@ -30,7 +33,8 @@ RUN apt update && \
 RUN pecl install xdebug-3.3.2 \
     && docker-php-ext-enable xdebug
 
-RUN useradd -ms /bin/bash phpuser
+RUN addgroup --gid "$GID" phpuser
+RUN adduser --uid "$UID" --gid "$GID" --disabled-password phpuser
 USER phpuser
 WORKDIR /home/phpuser
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -33,7 +33,7 @@ RUN apt update && \
 RUN pecl install xdebug-3.3.2 \
     && docker-php-ext-enable xdebug
 
-RUN addgroup --gid "$GID" phpuser
+RUN getent group "$GID" || addgroup --gid "$GID" phpuser
 RUN adduser --uid "$UID" --gid "$GID" --disabled-password phpuser
 USER phpuser
 WORKDIR /home/phpuser

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -2,6 +2,10 @@ version: 3
 
 env:
   REPOSITORY: alma-monthlypayments-magento2
+  HOST_UID:
+    sh: id -u
+  HOST_GID:
+    sh: id -g
 
 tasks:
 

--- a/Test/Unit/phpunit.ci.xml
+++ b/Test/Unit/phpunit.ci.xml
@@ -21,6 +21,10 @@
         </include>
     </coverage>
 
+    <listeners>
+        <listener class="Magento\Framework\TestFramework\Unit\Listener\ReplaceObjectManager"/>
+    </listeners>
+
     <testsuites>
         <testsuite name="Alma Monthly Payment for Magento 2 Unit Test Suite">
             <directory>.</directory>

--- a/compose.yml
+++ b/compose.yml
@@ -6,7 +6,8 @@ services:
       args:
         PHP_VERSION: ${PHP_VERSION:-8.1}
         MAGENTO_VERSION: ${MAGENTO_VERSION:-2.4.6-p6}
-    user: ${UID:-1000}:${GID:-1000}
+        UID: ${HOST_UID:-1000}
+        GID: ${HOST_GID:-1000}
     volumes:
       - ./:/home/phpuser/magento2/app/code/Alma/MonthlyPayments/
     environment:


### PR DESCRIPTION
### Reason for change

<!-- Describe here the reason for change, and provide a link to the corresponding Linear task or Sentry issue. -->
Fixes [DEX-697 🏃 Docker compose to run unit test from Adobe Commerce repository](https://linear.app/almapay/issue/DEX-697/docker-compose-to-run-unit-test-from-adobe-commerce-repository)
Lint has been failing since it has been introduced, as some work is needed to make the code compliant
Because of this, unit tests step with coverage was not executed in the CI

### Code changes

<!-- Describe here the code changes at a high level. Anything that can help reviewers review your PR. -->
Run lint and unit tests in separate jobs
There was a permission issue with a phpunit cache file in the test job (See https://github.com/alma/alma-monthlypayments-magento2/actions/runs/11276969408/job/31362033516), so I had to add some modifications

> [!NOTE]  
> * ~~Can someone run `task test` on this branch on MacOS to check that it is working properly ?~~ => OK on France's MAC after a fix
