### PR TITLE
Fix compatibility with parent::__construct form Fieldset 2.3.7

### DIFF
--- a/Block/Adminhtml/System/Config/Fieldset/Payment.php
+++ b/Block/Adminhtml/System/Config/Fieldset/Payment.php
@@ -34,15 +34,13 @@ use Magento\Config\Block\System\Config\Form\Fieldset;
 use Magento\Framework\App\Area;
 use Magento\Framework\Data\Form\Element\AbstractElement;
 use Magento\Framework\View\Helper\Js;
-use Magento\Framework\View\Helper\SecureHtmlRenderer;
 
 class Payment extends Fieldset
 {
 
     private $logger;
     private $apiConfigHelper;
-    private $config
-    ;
+    private $config;
 
     /**
      * @param Context $context
@@ -52,19 +50,18 @@ class Payment extends Fieldset
      * @param ApiConfigHelper $apiConfigHelper
      * @param Config $config
      * @param array $data
-     * @param SecureHtmlRenderer|null $secureRenderer
      */
     public function __construct(
-        Context             $context,
-        Session             $authSession,
-        Js                  $jsHelper,
-        Logger              $logger,
-        ApiConfigHelper     $apiConfigHelper,
-        Config              $config,
-        array               $data = [],
-        ?SecureHtmlRenderer $secureRenderer = null
-    ) {
-        parent::__construct($context, $authSession, $jsHelper, $data, $secureRenderer);
+        Context         $context,
+        Session         $authSession,
+        Js              $jsHelper,
+        Logger          $logger,
+        ApiConfigHelper $apiConfigHelper,
+        Config          $config,
+        array           $data = []
+    )
+    {
+        parent::__construct($context, $authSession, $jsHelper, $data);
         $this->logger = $logger;
         $this->apiConfigHelper = $apiConfigHelper;
         $this->config = $config;


### PR DESCRIPTION
### Reason for change

<!-- Describe here the reason for change, and provide a link to the corresponding Linear task or Sentry issue. -->

[Linear task](https://linear.app/almapay/issue/ECOM-2154/[ac]-fix-compatibility-with-237-securerenderhtml-in-paymentphp)

### Code changes
Remove secrurenderHtml from parent constructor
<!-- Describe here the code changes at a high level. Anything that can help reviewers review your PR. -->

### How to test

Run adobe 2-3-7 and connect to payment configuration page in admin 

_As a reviewer, you are encouraged to test the PR locally._

<!-- Describe here how to test your changes, if applicable. Insert UI screenshots when relevant -->

### Checklist for authors and reviewers

<!-- Move to the next section the non applicable items -->


### Non applicable

<!-- Move here non applicable items of the checklist, if any -->
