### PR TITLE
Implement merchant business event

### DIFF
--- a/Helpers/Eligibility.php
+++ b/Helpers/Eligibility.php
@@ -33,6 +33,7 @@ use Alma\MonthlyPayments\Helpers;
 use Alma\MonthlyPayments\Helpers\Exceptions\AlmaClientException;
 use Alma\MonthlyPayments\Model\Data\PaymentPlanEligibility;
 use Alma\MonthlyPayments\Model\Data\Quote as AlmaQuote;
+use Alma\MonthlyPayments\Services\MerchantBusinessService;
 use Magento\Framework\App\Helper\AbstractHelper;
 use Magento\Framework\App\Helper\Context;
 use Magento\Framework\Exception\InputException;
@@ -87,6 +88,10 @@ class Eligibility extends AbstractHelper
      * @var QuoteHelper
      */
     private $quoteHelper;
+    /**
+     * @var MerchantBusinessService
+     */
+    private $merchantBusinessService;
 
     /**
      * Eligibility constructor.
@@ -98,16 +103,19 @@ class Eligibility extends AbstractHelper
      * @param Config $config
      * @param AlmaQuote $quoteData
      * @param QuoteHelper $quoteHelper
+     * @param MerchantBusinessService $merchantBusinessService
      */
     public function __construct(
-        Context $context,
-        Data $pricingHelper,
-        Helpers\AlmaClient $almaClient,
-        Helpers\Logger $logger,
-        Config $config,
-        AlmaQuote $quoteData,
-        QuoteHelper $quoteHelper
-    ) {
+        Context                 $context,
+        Data                    $pricingHelper,
+        Helpers\AlmaClient      $almaClient,
+        Helpers\Logger          $logger,
+        Config                  $config,
+        AlmaQuote               $quoteData,
+        QuoteHelper             $quoteHelper,
+        MerchantBusinessService $merchantBusinessService
+    )
+    {
         parent::__construct($context);
         $this->pricingHelper = $pricingHelper;
         $this->alma = $almaClient;
@@ -119,6 +127,7 @@ class Eligibility extends AbstractHelper
         $this->eligible = false;
         $this->currentFeePlans = [];
         $this->message = '';
+        $this->merchantBusinessService = $merchantBusinessService;
     }
 
     /**
@@ -151,9 +160,9 @@ class Eligibility extends AbstractHelper
 
         $cartTotal = Functions::priceToCents((float)$quote->getGrandTotal());
         // Get enabled plans in BO and build a list of installments counts that should be tested for eligibility
-        $enabledPlansInConfig      = $this->getEnabledConfigPaymentPlans();
-        $installmentsQuery         = [];
-        $availablePlansKeyInBo     = [];
+        $enabledPlansInConfig = $this->getEnabledConfigPaymentPlans();
+        $installmentsQuery = [];
+        $availablePlansKeyInBo = [];
 
         foreach ($enabledPlansInConfig as $planKey => $planConfig) {
             if (
@@ -174,6 +183,7 @@ class Eligibility extends AbstractHelper
 
         if (empty($installmentsQuery)) {
             $this->logger->info('No eligible installment in config for this amount', [$cartTotal]);
+            $this->merchantBusinessService->quoteNotEligibleForBNPL($quote);
             return [];
         }
 
@@ -182,8 +192,9 @@ class Eligibility extends AbstractHelper
                 $this->quoteData->eligibilityDataFromQuote($quote, $installmentsQuery),
                 true
             );
-        } catch (RequestError | AlmaClientException $e) {
+        } catch (RequestError|AlmaClientException $e) {
             $this->logger->error('Get plan eligibility exception', [$e->getMessage()]);
+            $this->merchantBusinessService->quoteNotEligibleForBNPL($quote);
             return [];
         }
 
@@ -191,7 +202,7 @@ class Eligibility extends AbstractHelper
 
         $plansEligibility = [];
         foreach ($availablePlansKeyInBo as $planKey) {
-            $planConfig  = $this->getPlanConfigFromKey($enabledPlansInConfig, $planKey);
+            $planConfig = $this->getPlanConfigFromKey($enabledPlansInConfig, $planKey);
 
             if (!$planConfig) {
                 $this->logger->info('No Plan Config', ['planKey' => $planKey]);
@@ -207,6 +218,12 @@ class Eligibility extends AbstractHelper
         }
         $feePlans = array_values($plansEligibility);
         $this->setCurrentsFeePlans($feePlans);
+        $this->merchantBusinessService->quoteNotEligibleForBNPL($quote);
+        if (array_filter($feePlans, function ($feePlan) {
+            return $feePlan->getPlanConfig()->planKey() !== PaymentPlansHelper::PAY_NOW_KEY;
+        })) {
+            $this->merchantBusinessService->quoteIsEligibleForBNPL($quote);
+        }
         return $feePlans;
     }
 
@@ -314,7 +331,7 @@ class Eligibility extends AbstractHelper
 
     /**
      * @param PaymentPlanConfigInterface[] $plansConfig
-     * @param string                       $planKey
+     * @param string $planKey
      *
      * @return null|PaymentPlanConfigInterface
      */
@@ -380,7 +397,7 @@ class Eligibility extends AbstractHelper
         $hasFeePlans = false;
         if (count($feePlans) > 0) {
             $this->currentFeePlans = $feePlans;
-            $hasFeePlans  = true;
+            $hasFeePlans = true;
         }
         $this->setIsAlreadyLoaded($hasFeePlans);
     }
@@ -433,7 +450,7 @@ class Eligibility extends AbstractHelper
             }
         }
         if ($minPurchaseAmount === null) {
-            $minPurchaseAmount =  0;
+            $minPurchaseAmount = 0;
         }
         return $minPurchaseAmount;
     }
@@ -456,7 +473,7 @@ class Eligibility extends AbstractHelper
             }
         }
         if ($maxPurchaseAmount === null) {
-            $maxPurchaseAmount =  0;
+            $maxPurchaseAmount = 0;
         }
         return $maxPurchaseAmount;
     }

--- a/Helpers/Eligibility.php
+++ b/Helpers/Eligibility.php
@@ -218,12 +218,13 @@ class Eligibility extends AbstractHelper
         }
         $feePlans = array_values($plansEligibility);
         $this->setCurrentsFeePlans($feePlans);
-        $this->merchantBusinessService->quoteNotEligibleForBNPL($quote);
+        $isEligible = false;
         if (array_filter($feePlans, function ($feePlan) {
             return $feePlan->getPlanConfig()->planKey() !== PaymentPlansHelper::PAY_NOW_KEY;
         })) {
-            $this->merchantBusinessService->quoteIsEligibleForBNPL($quote);
+            $isEligible = true;
         }
+        $isEligible ? $this->merchantBusinessService->quoteIsEligibleForBNPL($quote) : $this->merchantBusinessService->quoteNotEligibleForBNPL($quote);
         return $feePlans;
     }
 

--- a/Model/Exceptions/MerchantBusinessServiceException.php
+++ b/Model/Exceptions/MerchantBusinessServiceException.php
@@ -1,0 +1,10 @@
+<?php
+
+namespace Alma\MonthlyPayments\Model\Exceptions;
+
+use Alma\MonthlyPayments\Model\Exceptions\AlmaException;
+
+class MerchantBusinessServiceException extends AlmaException
+{
+
+}

--- a/Observer/SalesOrderInvoicePayObserver.php
+++ b/Observer/SalesOrderInvoicePayObserver.php
@@ -56,7 +56,6 @@ class SalesOrderInvoicePayObserver implements ObserverInterface
         ApiConfigHelper                 $apiConfigHelper,
         InsuranceSendCustomerCartHelper $insuranceSendCustomerCartHelper,
         MerchantBusinessService         $merchantBusinessService
-
     )
     {
         $this->logger = $logger;

--- a/Observer/SalesOrderInvoicePayObserver.php
+++ b/Observer/SalesOrderInvoicePayObserver.php
@@ -8,7 +8,9 @@ use Alma\MonthlyPayments\Helpers\ApiConfigHelper;
 use Alma\MonthlyPayments\Helpers\InsuranceHelper;
 use Alma\MonthlyPayments\Helpers\InsuranceSendCustomerCartHelper;
 use Alma\MonthlyPayments\Helpers\Logger;
+use Alma\MonthlyPayments\Model\Exceptions\MerchantBusinessServiceException;
 use Alma\MonthlyPayments\Model\Insurance\ResourceModel\Subscription;
+use Alma\MonthlyPayments\Services\MerchantBusinessService;
 use Magento\Framework\Event\Observer;
 use Magento\Framework\Event\ObserverInterface;
 use Magento\Framework\Exception\AlreadyExistsException;
@@ -37,7 +39,14 @@ class SalesOrderInvoicePayObserver implements ObserverInterface
      * @var ApiConfigHelper
      */
     private $apiConfigHelper;
+    /**
+     * @var InsuranceSendCustomerCartHelper
+     */
     private $insuranceSendCustomerCartHelper;
+    /**
+     * @var MerchantBusinessService
+     */
+    private $merchantBusinessService;
 
     public function __construct(
         Logger                          $logger,
@@ -45,14 +54,18 @@ class SalesOrderInvoicePayObserver implements ObserverInterface
         AlmaClient                      $almaClient,
         Subscription                    $subscriptionResourceModel,
         ApiConfigHelper                 $apiConfigHelper,
-        InsuranceSendCustomerCartHelper $insuranceSendCustomerCartHelper
-    ) {
+        InsuranceSendCustomerCartHelper $insuranceSendCustomerCartHelper,
+        MerchantBusinessService         $merchantBusinessService
+
+    )
+    {
         $this->logger = $logger;
         $this->insuranceHelper = $insuranceHelper;
         $this->almaClient = $almaClient;
         $this->subscriptionResourceModel = $subscriptionResourceModel;
         $this->apiConfigHelper = $apiConfigHelper;
         $this->insuranceSendCustomerCartHelper = $insuranceSendCustomerCartHelper;
+        $this->merchantBusinessService = $merchantBusinessService;
     }
 
     /**
@@ -62,6 +75,14 @@ class SalesOrderInvoicePayObserver implements ObserverInterface
     {
         /** @var Invoice $invoice */
         $invoice = $observer->getEvent()->getData('invoice');
+
+        try {
+            $orderConfirmedBusinessEventDTO = $this->merchantBusinessService->createOrderConfirmedBusinessEventByOrder($invoice->getOrder());
+            $this->merchantBusinessService->sendOrderConfirmedBusinessEvent($orderConfirmedBusinessEventDTO);
+        } catch (MerchantBusinessServiceException $e) {
+            $this->logger->error('Error sending Order Confirmed Business Event observer', ['exception' => $e]);
+        }
+
         $billingAddress = $invoice->getBillingAddress();
         $subscriber = $this->insuranceHelper->getSubscriberByAddress($billingAddress);
 

--- a/Observer/SalesQuoteSaveAfterObserver.php
+++ b/Observer/SalesQuoteSaveAfterObserver.php
@@ -1,0 +1,51 @@
+<?php
+
+namespace Alma\MonthlyPayments\Observer;
+
+
+use Alma\MonthlyPayments\Helpers\Logger;
+use Alma\MonthlyPayments\Services\MerchantBusinessService;
+use Magento\Framework\Event\Observer;
+use Magento\Framework\Event\ObserverInterface;
+use Magento\Quote\Model\Quote;
+
+
+class SalesQuoteSaveAfterObserver implements ObserverInterface
+{
+    /**
+     * @var Logger
+     */
+    private $logger;
+    /**
+     * @var MerchantBusinessService
+     */
+    private $merchantBusinessService;
+
+    /**
+     * @param Logger $logger
+     * @param MerchantBusinessService $merchantBusinessService
+     */
+    public function __construct(
+        Logger                  $logger,
+        MerchantBusinessService $merchantBusinessService
+    )
+    {
+        $this->logger = $logger;
+        $this->merchantBusinessService = $merchantBusinessService;
+    }
+
+    /**
+     * @param Observer $observer
+     * @return void
+     */
+    public function execute(Observer $observer): void
+    {
+        /** @var Quote $quote */
+        $quote = $observer->getEvent()->getData('quote');
+        if (!$this->merchantBusinessService->isSendCartInitiatedNotification($quote)) {
+            $this->merchantBusinessService->createAndSendCartInitiatedBusinessEvent($quote);
+        }
+    }
+
+
+}

--- a/Services/MerchantBusinessService.php
+++ b/Services/MerchantBusinessService.php
@@ -48,6 +48,31 @@ class MerchantBusinessService
         $this->quoteRepository = $quoteRepository;
     }
 
+
+    /**
+     * Set alma_bnpl_eligibility to true in quote DB
+     *
+     * @param Quote $quote
+     * @return void
+     */
+    public function quoteIsEligibleForBNPL(Quote $quote): void
+    {
+        $quote->setData(self::QUOTE_BNPL_ELIGIBILITY_KEY, true);
+        $this->quoteRepository->save($quote);
+    }
+
+    /**
+     * Set alma_bnpl_eligibility to false in quote DB
+     *
+     * @param Quote $quote
+     * @return void
+     */
+    public function quoteNotEligibleForBNPL(Quote $quote): void
+    {
+        $quote->setData(self::QUOTE_BNPL_ELIGIBILITY_KEY, false);
+        $this->quoteRepository->save($quote);
+    }
+
     /**
      * Generate OrderConfirmed DTO
      *

--- a/Services/MerchantBusinessService.php
+++ b/Services/MerchantBusinessService.php
@@ -11,6 +11,7 @@ use Alma\MonthlyPayments\Helpers\Logger;
 use Alma\MonthlyPayments\Helpers\PaymentPlansHelper;
 use Alma\MonthlyPayments\Model\Exceptions\MerchantBusinessServiceException;
 use Magento\Framework\Exception\NoSuchEntityException;
+use Magento\Quote\Api\Data\CartInterface;
 use Magento\Quote\Model\Quote;
 use Magento\Quote\Model\QuoteRepository;
 use Magento\Sales\Model\Order;
@@ -52,10 +53,10 @@ class MerchantBusinessService
     /**
      * Set alma_bnpl_eligibility to true in quote DB
      *
-     * @param Quote $quote
+     * @param CartInterface $quote
      * @return void
      */
-    public function quoteIsEligibleForBNPL(Quote $quote): void
+    public function quoteIsEligibleForBNPL(CartInterface $quote): void
     {
         $quote->setData(self::QUOTE_BNPL_ELIGIBILITY_KEY, true);
         $this->quoteRepository->save($quote);
@@ -64,10 +65,10 @@ class MerchantBusinessService
     /**
      * Set alma_bnpl_eligibility to false in quote DB
      *
-     * @param Quote $quote
+     * @param CartInterface $quote
      * @return void
      */
-    public function quoteNotEligibleForBNPL(Quote $quote): void
+    public function quoteNotEligibleForBNPL(CartInterface $quote): void
     {
         $quote->setData(self::QUOTE_BNPL_ELIGIBILITY_KEY, false);
         $this->quoteRepository->save($quote);

--- a/Services/MerchantBusinessService.php
+++ b/Services/MerchantBusinessService.php
@@ -1,0 +1,101 @@
+<?php
+
+namespace Alma\MonthlyPayments\Services;
+
+
+use Alma\API\Entities\DTO\MerchantBusinessEvent\OrderConfirmedBusinessEvent;
+use Alma\API\Exceptions\AlmaException;
+use Alma\API\Exceptions\ParametersException;
+use Alma\MonthlyPayments\Helpers\AlmaClient;
+use Alma\MonthlyPayments\Helpers\Logger;
+use Alma\MonthlyPayments\Helpers\PaymentPlansHelper;
+use Alma\MonthlyPayments\Model\Exceptions\MerchantBusinessServiceException;
+use Magento\Framework\Exception\NoSuchEntityException;
+use Magento\Quote\Model\Quote;
+use Magento\Quote\Model\QuoteRepository;
+use Magento\Sales\Model\Order;
+
+class MerchantBusinessService
+{
+    const QUOTE_BNPL_ELIGIBILITY_KEY = 'alma_bnpl_eligibility';
+    /**
+     * @var AlmaClient
+     */
+    private $almaClient;
+    /**
+     * @var Logger
+     */
+    private $logger;
+    /**
+     * @var QuoteRepository
+     */
+    private $quoteRepository;
+
+
+    /**
+     * @param AlmaClient $almaClient
+     * @param Logger $logger
+     * @param QuoteRepository $quoteRepository
+     */
+    public function __construct(
+        AlmaClient      $almaClient,
+        Logger          $logger,
+        QuoteRepository $quoteRepository
+    )
+    {
+        $this->almaClient = $almaClient;
+        $this->logger = $logger;
+        $this->quoteRepository = $quoteRepository;
+    }
+
+    /**
+     * Generate OrderConfirmed DTO
+     *
+     * @param Order $order
+     * @return OrderConfirmedBusinessEvent
+     * @throws MerchantBusinessServiceException
+     */
+    public function createOrderConfirmedBusinessEventByOrder(Order $order): OrderConfirmedBusinessEvent
+    {
+        $planKey = $order->getPayment()->getAdditionalInformation()['selectedPlan'] ?? '';
+        $isPayNow = PaymentPlansHelper::PAY_NOW_KEY === $planKey;
+        $isBNPL = !$isPayNow && preg_match('!general:[\d]+:[\d]+:[\d]+!', $planKey);
+
+        try {
+            /** @var Quote $quote */
+            $quote = $this->quoteRepository->get($order->getQuoteId());
+        } catch (NoSuchEntityException $e) {
+            $this->logger->error('Create Order confirmed business event get quote error :', [$e->getMessage()]);
+            throw new MerchantBusinessServiceException('Create Order confirmed business event : quote not found');
+        }
+        try {
+            return new OrderConfirmedBusinessEvent(
+                $isPayNow,
+                $isBNPL,
+                (bool)$quote->getData(self::QUOTE_BNPL_ELIGIBILITY_KEY),
+                $order->getId(),
+                $order->getQuoteId(),
+                $order->getPayment()->getAdditionalInformation()['PAYMENT_ID'] ?? null
+            );
+        } catch (ParametersException $e) {
+            $this->logger->error('New Order confirmed business event error :', [$e->getMessage()]);
+            throw new MerchantBusinessServiceException('Create Order confirmed business event : Impossible to construct DTO');
+        }
+    }
+
+    /**
+     * Send Order Confirmed event with PHP Client
+     *
+     * @param OrderConfirmedBusinessEvent $orderConfirmedMock
+     * @return void
+     */
+    public function sendOrderConfirmedBusinessEvent(OrderConfirmedBusinessEvent $orderConfirmedMock)
+    {
+        try {
+            $this->almaClient->getDefaultClient()->merchants->sendOrderConfirmedBusinessEvent($orderConfirmedMock);
+        } catch (AlmaException $e) {
+            $this->logger->error('sendOrderConfirmedBusinessEvent : ', [$e->getMessage()]);
+        }
+    }
+}
+

--- a/Test/Unit/Observer/SalesQuoteSaveAfterObserverTest.php
+++ b/Test/Unit/Observer/SalesQuoteSaveAfterObserverTest.php
@@ -1,0 +1,83 @@
+<?php
+
+namespace Alma\MonthlyPayments\Test\Unit\Observer;
+
+use Alma\MonthlyPayments\Helpers\Logger;
+use Alma\MonthlyPayments\Observer\SalesQuoteSaveAfterObserver;
+use Alma\MonthlyPayments\Services\MerchantBusinessService;
+use Magento\Framework\Event;
+use Magento\Framework\Event\Observer;
+use Magento\Quote\Model\Quote;
+use PHPUnit\Framework\TestCase;
+
+class SalesQuoteSaveAfterObserverTest extends TestCase
+{
+
+    /**
+     * @var Logger
+     */
+    private $logger;
+
+    /**
+     * @var MerchantBusinessService
+     */
+    private $merchantBusinessService;
+    /**
+     * @var SalesQuoteSaveAfterObserver
+     */
+    private $salesQuoteSaveAfterObserver;
+
+    public function setUp(): void
+    {
+        $this->logger = $this->createMock(Logger::class);
+        $this->merchantBusinessService = $this->createMock(MerchantBusinessService::class);
+        $this->salesQuoteSaveAfterObserver = new SalesQuoteSaveAfterObserver(
+            $this->logger,
+            $this->merchantBusinessService
+        );
+    }
+
+    public function testExecuteCartInitiatedNotificationNotSend()
+    {
+        $observer = $this->createMock(Observer::class);
+        $quote = $this->createMock(Quote::class);
+        $event = $this->createMock(Event::class);
+        $event->method('getData')->with('quote')->willReturn($quote);
+        $observer->method('getEvent')->willReturn($event);
+        $quote->method('getId')->willReturn(42);
+        $this->merchantBusinessService
+            ->expects($this->once())
+            ->method('isSendCartInitiatedNotification')
+            ->with($quote)
+            ->willReturn(false);
+        $this->merchantBusinessService
+            ->expects($this->once())
+            ->method('createAndSendCartInitiatedBusinessEvent')
+            ->with($quote);
+
+        $this->salesQuoteSaveAfterObserver->execute($observer);
+    }
+
+    public function testExecuteCartInitiatedNotificationAlreadySend()
+    {
+        $observer = $this->createMock(Observer::class);
+        $quote = $this->createMock(Quote::class);
+        $event = $this->createMock(Event::class);
+        $event->method('getData')->with('quote')->willReturn($quote);
+        $observer->method('getEvent')->willReturn($event);
+        $quote->method('getId')->willReturn(42);
+        $this->merchantBusinessService
+            ->expects($this->once())
+            ->method('isSendCartInitiatedNotification')
+            ->with($quote)
+            ->willReturn(true);
+
+        $this->merchantBusinessService
+            ->expects($this->never())
+            ->method('createAndSendCartInitiatedBusinessEvent')
+            ->with($quote);
+
+        $this->salesQuoteSaveAfterObserver->execute($observer);
+    }
+
+}

--- a/Test/Unit/Services/MerchantBusinessServiceTest.php
+++ b/Test/Unit/Services/MerchantBusinessServiceTest.php
@@ -120,9 +120,9 @@ class MerchantBusinessServiceTest extends TestCase
 
         $dto = $this->merchantBusinessService->createOrderConfirmedBusinessEventByOrder($orderMock);
         $this->assertInstanceOf(OrderConfirmedBusinessEvent::class, $dto);
-        $this->assertEquals(false, $dto->isAlmaP1X());
-        $this->assertEquals(false, $dto->isAlmaBNPL());
-        $this->assertEquals(false, $dto->wasBNPLEligible());
+        $this->assertFalse($dto->isAlmaP1X());
+        $this->assertFalse($dto->isAlmaBNPL());
+        $this->assertFalse($dto->wasBNPLEligible());
         $this->assertEquals('42', $dto->getOrderId());
         $this->assertEquals('12', $dto->getCartId());
         $this->assertNull($dto->getAlmaPaymentId());
@@ -155,9 +155,9 @@ class MerchantBusinessServiceTest extends TestCase
 
         $dto = $this->merchantBusinessService->createOrderConfirmedBusinessEventByOrder($orderMock);
         $this->assertInstanceOf(OrderConfirmedBusinessEvent::class, $dto);
-        $this->assertEquals(false, $dto->isAlmaP1X());
-        $this->assertEquals(true, $dto->isAlmaBNPL());
-        $this->assertEquals(true, $dto->wasBNPLEligible());
+        $this->assertFalse($dto->isAlmaP1X());
+        $this->assertTrue($dto->isAlmaBNPL());
+        $this->assertTrue($dto->wasBNPLEligible());
         $this->assertEquals('42', $dto->getOrderId());
         $this->assertEquals('12', $dto->getCartId());
         $this->assertEquals('alma_payment_external_id', $dto->getAlmaPaymentId());
@@ -190,9 +190,9 @@ class MerchantBusinessServiceTest extends TestCase
 
         $dto = $this->merchantBusinessService->createOrderConfirmedBusinessEventByOrder($orderMock);
         $this->assertInstanceOf(OrderConfirmedBusinessEvent::class, $dto);
-        $this->assertEquals(true, $dto->isAlmaP1X());
-        $this->assertEquals(false, $dto->isAlmaBNPL());
-        $this->assertEquals(true, $dto->wasBNPLEligible());
+        $this->assertTrue($dto->isAlmaP1X());
+        $this->assertFalse($dto->isAlmaBNPL());
+        $this->assertTrue($dto->wasBNPLEligible());
         $this->assertEquals('42', $dto->getOrderId());
         $this->assertEquals('12', $dto->getCartId());
         $this->assertEquals('alma_payment_external_id', $dto->getAlmaPaymentId());

--- a/Test/Unit/Services/MerchantBusinessServiceTest.php
+++ b/Test/Unit/Services/MerchantBusinessServiceTest.php
@@ -42,6 +42,33 @@ class MerchantBusinessServiceTest extends TestCase
         );
     }
 
+    public function testSeQuoteIsEligibleForBNPLCallQuoteRepository()
+    {
+        $quote = $this->createMock(Quote::class);
+        $quote
+            ->expects($this->once())
+            ->method('setData')
+            ->with('alma_bnpl_eligibility', true);
+        $this->quoteRepository
+            ->expects($this->once())
+            ->method('save')
+            ->with($quote);
+        $this->merchantBusinessService->quoteIsEligibleForBNPL($quote);
+    }
+
+    public function testSeQuoteNotEligibleForBNPLCallQuoteRepository()
+    {
+        $quote = $this->createMock(Quote::class);
+        $quote
+            ->expects($this->once())
+            ->method('setData')
+            ->with('alma_bnpl_eligibility', false);
+        $this->quoteRepository
+            ->expects($this->once())
+            ->method('save')
+            ->with($quote);
+        $this->merchantBusinessService->quoteNotEligibleForBNPL($quote);
+    }
 
     public function testSendOrderConfirmedCallPhpClient()
     {

--- a/Test/Unit/Services/MerchantBusinessServiceTest.php
+++ b/Test/Unit/Services/MerchantBusinessServiceTest.php
@@ -1,0 +1,221 @@
+<?php
+
+namespace Alma\MonthlyPayments\Test\Unit\Services;
+
+use Alma\API\Client;
+use Alma\API\Endpoints\Merchants;
+use Alma\API\Entities\DTO\MerchantBusinessEvent\OrderConfirmedBusinessEvent;
+use Alma\API\Exceptions\RequestException;
+use Alma\MonthlyPayments\Helpers\AlmaClient;
+use Alma\MonthlyPayments\Helpers\Logger;
+use Alma\MonthlyPayments\Model\Exceptions\MerchantBusinessServiceException;
+use Alma\MonthlyPayments\Services\MerchantBusinessService;
+use Magento\Framework\Exception\NoSuchEntityException;
+use Magento\Quote\Model\Quote;
+use Magento\Quote\Model\QuoteRepository;
+use Magento\Sales\Api\Data\OrderPaymentInterface;
+use Magento\Sales\Model\Order;
+use PHPUnit\Framework\TestCase;
+
+class MerchantBusinessServiceTest extends TestCase
+{
+    private $almaClient;
+    private $logger;
+    private $merchantEndpoint;
+    private $merchantBusinessService;
+    private $quoteRepository;
+
+    public function setUp(): void
+    {
+        $this->merchantEndpoint = $this->createMock(Merchants::class);
+        $client = $this->createMock(Client::class);
+        $client->merchants = $this->merchantEndpoint;
+        $this->almaClient = $this->createMock(AlmaClient::class);
+        $this->almaClient->method('getDefaultClient')->willReturn($client);
+        $this->logger = $this->createMock(Logger::class);
+        $this->quoteRepository = $this->createMock(QuoteRepository::class);
+
+        $this->merchantBusinessService = new MerchantBusinessService(
+            $this->almaClient,
+            $this->logger,
+            $this->quoteRepository
+        );
+    }
+
+
+    public function testSendOrderConfirmedCallPhpClient()
+    {
+        $orderConfirmedMock = $this->createMock(OrderConfirmedBusinessEvent::class);
+        $this->merchantEndpoint
+            ->expects($this->once())
+            ->method('sendOrderConfirmedBusinessEvent')
+            ->with($orderConfirmedMock);
+        $this->assertNull($this->merchantBusinessService->sendOrderConfirmedBusinessEvent($orderConfirmedMock));
+    }
+
+    public function testSendOrderConfirmedLogErrorButNotThrowException()
+    {
+        $orderConfirmedMock = $this->createMock(OrderConfirmedBusinessEvent::class);
+        $this->merchantEndpoint
+            ->expects($this->once())
+            ->method('sendOrderConfirmedBusinessEvent')
+            ->with($orderConfirmedMock)
+            ->willThrowException(new RequestException('Error in send'));
+        $this->logger
+            ->expects($this->once())
+            ->method('error');
+        $this->assertNull($this->merchantBusinessService->sendOrderConfirmedBusinessEvent($orderConfirmedMock));
+    }
+
+    public function testCreateOrderConfirmedWithNonAlmaPaymentReturnOrderConfirmedObject()
+    {
+        $paymentMock = $this->createMock(OrderPaymentInterface::class);
+        $paymentMock->method('getAdditionalInformation')
+            ->willReturn([]);
+        $quote = $this->createMock(Quote::class);
+        $orderMock = $this->createMock(Order::class);
+        $orderMock
+            ->method('getPayment')
+            ->willReturn($paymentMock);
+        $orderMock
+            ->method('getId')
+            ->willReturn('42');
+        $orderMock
+            ->method('getQuoteId')
+            ->willReturn('12');
+        $quote
+            ->method('getData')
+            ->with('alma_bnpl_eligibility')
+            ->willReturn(false);
+        $this->quoteRepository
+            ->method('get')
+            ->willReturn($quote);
+
+        $dto = $this->merchantBusinessService->createOrderConfirmedBusinessEventByOrder($orderMock);
+        $this->assertInstanceOf(OrderConfirmedBusinessEvent::class, $dto);
+        $this->assertEquals(false, $dto->isAlmaP1X());
+        $this->assertEquals(false, $dto->isAlmaBNPL());
+        $this->assertEquals(false, $dto->wasBNPLEligible());
+        $this->assertEquals('42', $dto->getOrderId());
+        $this->assertEquals('12', $dto->getCartId());
+        $this->assertNull($dto->getAlmaPaymentId());
+    }
+
+    public function testCreateOrderConfirmedWithAlmaPaymentReturnOrderConfirmedObject()
+    {
+        $paymentMock = $this->createMock(OrderPaymentInterface::class);
+        $paymentMock->method('getAdditionalInformation')
+            ->willReturn(['PAYMENT_ID' => 'alma_payment_external_id', 'selectedPlan' => 'general:1:15:0']);
+        $quote = $this->createMock(Quote::class);
+
+        $orderMock = $this->createMock(Order::class);
+        $orderMock
+            ->method('getPayment')
+            ->willReturn($paymentMock);
+        $orderMock
+            ->method('getId')
+            ->willReturn('42');
+        $orderMock
+            ->method('getQuoteId')
+            ->willReturn('12');
+        $quote
+            ->method('getData')
+            ->with('alma_bnpl_eligibility')
+            ->willReturn(true);
+        $this->quoteRepository
+            ->method('get')
+            ->willReturn($quote);
+
+        $dto = $this->merchantBusinessService->createOrderConfirmedBusinessEventByOrder($orderMock);
+        $this->assertInstanceOf(OrderConfirmedBusinessEvent::class, $dto);
+        $this->assertEquals(false, $dto->isAlmaP1X());
+        $this->assertEquals(true, $dto->isAlmaBNPL());
+        $this->assertEquals(true, $dto->wasBNPLEligible());
+        $this->assertEquals('42', $dto->getOrderId());
+        $this->assertEquals('12', $dto->getCartId());
+        $this->assertEquals('alma_payment_external_id', $dto->getAlmaPaymentId());
+    }
+
+    public function testCreateOrderConfirmedWithAlmaPayNowReturnOrderConfirmedObject()
+    {
+        $paymentMock = $this->createMock(OrderPaymentInterface::class);
+        $paymentMock->method('getAdditionalInformation')
+            ->willReturn(['PAYMENT_ID' => 'alma_payment_external_id', 'selectedPlan' => 'general:1:0:0']);
+        $quote = $this->createMock(Quote::class);
+
+        $orderMock = $this->createMock(Order::class);
+        $orderMock
+            ->method('getPayment')
+            ->willReturn($paymentMock);
+        $orderMock
+            ->method('getId')
+            ->willReturn('42');
+        $orderMock
+            ->method('getQuoteId')
+            ->willReturn('12');
+        $quote
+            ->method('getData')
+            ->with('alma_bnpl_eligibility')
+            ->willReturn(true);
+        $this->quoteRepository
+            ->method('get')
+            ->willReturn($quote);
+
+        $dto = $this->merchantBusinessService->createOrderConfirmedBusinessEventByOrder($orderMock);
+        $this->assertInstanceOf(OrderConfirmedBusinessEvent::class, $dto);
+        $this->assertEquals(true, $dto->isAlmaP1X());
+        $this->assertEquals(false, $dto->isAlmaBNPL());
+        $this->assertEquals(true, $dto->wasBNPLEligible());
+        $this->assertEquals('42', $dto->getOrderId());
+        $this->assertEquals('12', $dto->getCartId());
+        $this->assertEquals('alma_payment_external_id', $dto->getAlmaPaymentId());
+    }
+
+    public function testCreateOrderConfirmedThrowExceptionWhenQuoteNotFound()
+    {
+        $paymentMock = $this->createMock(OrderPaymentInterface::class);
+        $paymentMock->method('getAdditionalInformation')
+            ->willReturn(['PAYMENT_ID' => 'alma_payment_external_id', 'selectedPlan' => 'general:1:0:0']);
+        $orderMock = $this->createMock(Order::class);
+        $orderMock
+            ->method('getPayment')
+            ->willReturn($paymentMock);
+        $orderMock
+            ->method('getQuoteId')
+            ->willReturn('12');
+        $this->quoteRepository
+            ->method('get')
+            ->willThrowException(new NoSuchEntityException());
+        $this->expectException(MerchantBusinessServiceException::class);
+        $this->merchantBusinessService->createOrderConfirmedBusinessEventByOrder($orderMock);
+    }
+
+    public function testCreateOrderConfirmedThrowExceptionForBadDataTypeInConstruct()
+    {
+        $paymentMock = $this->createMock(OrderPaymentInterface::class);
+        $paymentMock->method('getAdditionalInformation')
+            ->willReturn(['PAYMENT_ID' => 'alma_payment_external_id', 'selectedPlan' => 'general:1:0:0']);
+        $quote = $this->createMock(Quote::class);
+
+        $orderMock = $this->createMock(Order::class);
+        $orderMock
+            ->method('getPayment')
+            ->willReturn($paymentMock);
+        $orderMock
+            ->method('getId')
+            ->willReturn(42);
+        $orderMock
+            ->method('getQuoteId')
+            ->willReturn(12);
+        $quote
+            ->method('getData')
+            ->with('alma_bnpl_eligibility')
+            ->willReturn(true);
+        $this->quoteRepository
+            ->method('get')
+            ->willReturn($quote);
+        $this->expectException(MerchantBusinessServiceException::class);
+        $this->merchantBusinessService->createOrderConfirmedBusinessEventByOrder($orderMock);
+    }
+
+}

--- a/Test/Unit/Services/MerchantBusinessServiceTest.php
+++ b/Test/Unit/Services/MerchantBusinessServiceTest.php
@@ -42,13 +42,13 @@ class MerchantBusinessServiceTest extends TestCase
         );
     }
 
-    public function testSeQuoteIsEligibleForBNPLCallQuoteRepository()
+    public function testSetQuoteIsEligibleForBNPLCallQuoteRepository()
     {
         $quote = $this->createMock(Quote::class);
         $quote
             ->expects($this->once())
             ->method('setData')
-            ->with('alma_bnpl_eligibility', true);
+            ->with('alma_bnpl_eligibility', '1');
         $this->quoteRepository
             ->expects($this->once())
             ->method('save')
@@ -56,13 +56,13 @@ class MerchantBusinessServiceTest extends TestCase
         $this->merchantBusinessService->quoteIsEligibleForBNPL($quote);
     }
 
-    public function testSeQuoteNotEligibleForBNPLCallQuoteRepository()
+    public function testSetQuoteNotEligibleForBNPLCallQuoteRepository()
     {
         $quote = $this->createMock(Quote::class);
         $quote
             ->expects($this->once())
             ->method('setData')
-            ->with('alma_bnpl_eligibility', false);
+            ->with('alma_bnpl_eligibility', '0');
         $this->quoteRepository
             ->expects($this->once())
             ->method('save')
@@ -105,7 +105,7 @@ class MerchantBusinessServiceTest extends TestCase
             ->method('getPayment')
             ->willReturn($paymentMock);
         $orderMock
-            ->method('getId')
+            ->method('getIncrementId')
             ->willReturn('42');
         $orderMock
             ->method('getQuoteId')
@@ -113,7 +113,7 @@ class MerchantBusinessServiceTest extends TestCase
         $quote
             ->method('getData')
             ->with('alma_bnpl_eligibility')
-            ->willReturn(false);
+            ->willReturn('0');
         $this->quoteRepository
             ->method('get')
             ->willReturn($quote);
@@ -140,7 +140,7 @@ class MerchantBusinessServiceTest extends TestCase
             ->method('getPayment')
             ->willReturn($paymentMock);
         $orderMock
-            ->method('getId')
+            ->method('getIncrementId')
             ->willReturn('42');
         $orderMock
             ->method('getQuoteId')
@@ -148,7 +148,7 @@ class MerchantBusinessServiceTest extends TestCase
         $quote
             ->method('getData')
             ->with('alma_bnpl_eligibility')
-            ->willReturn(true);
+            ->willReturn('1');
         $this->quoteRepository
             ->method('get')
             ->willReturn($quote);
@@ -175,7 +175,7 @@ class MerchantBusinessServiceTest extends TestCase
             ->method('getPayment')
             ->willReturn($paymentMock);
         $orderMock
-            ->method('getId')
+            ->method('getIncrementId')
             ->willReturn('42');
         $orderMock
             ->method('getQuoteId')
@@ -183,7 +183,7 @@ class MerchantBusinessServiceTest extends TestCase
         $quote
             ->method('getData')
             ->with('alma_bnpl_eligibility')
-            ->willReturn(true);
+            ->willReturn('1');
         $this->quoteRepository
             ->method('get')
             ->willReturn($quote);
@@ -230,14 +230,14 @@ class MerchantBusinessServiceTest extends TestCase
             ->willReturn($paymentMock);
         $orderMock
             ->method('getId')
-            ->willReturn(42);
+            ->willReturn(null);
         $orderMock
             ->method('getQuoteId')
-            ->willReturn(12);
+            ->willReturn('12');
         $quote
             ->method('getData')
             ->with('alma_bnpl_eligibility')
-            ->willReturn(true);
+            ->willReturn('1');
         $this->quoteRepository
             ->method('get')
             ->willReturn($quote);

--- a/etc/db_schema.xml
+++ b/etc/db_schema.xml
@@ -1,6 +1,8 @@
 <?xml version="1.0"?>
 <schema xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:framework:Setup/Declaration/Schema/etc/schema.xsd">
-
+    <table name="quote" resource="checkout" comment="Alma eligibility for quote">
+        <column xsi:type="boolean" name="alma_bnpl_eligibility" nullable="true" comment="Quote is eligible to alma BNPL"/>
+    </table>
     <table name="quote_item" resource="checkout" comment="Alma insurance Data in Quote Item">
         <column xsi:type="text" name="alma_insurance" nullable="true" comment="Alma insurance"/>
     </table>

--- a/etc/db_schema.xml
+++ b/etc/db_schema.xml
@@ -1,7 +1,11 @@
 <?xml version="1.0"?>
-<schema xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:framework:Setup/Declaration/Schema/etc/schema.xsd">
+<schema xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:noNamespaceSchemaLocation="urn:magento:framework:Setup/Declaration/Schema/etc/schema.xsd">
     <table name="quote" resource="checkout" comment="Alma eligibility for quote">
-        <column xsi:type="boolean" name="alma_bnpl_eligibility" nullable="true" comment="Quote is eligible to alma BNPL"/>
+        <column xsi:type="boolean" name="alma_bnpl_eligibility" nullable="true"
+                comment="Quote is eligible to alma BNPL"/>
+        <column xsi:type="boolean" name="alma_cart_initiated_status" nullable="false" default="false"
+                comment="Cart initiated notification status"/>
     </table>
     <table name="quote_item" resource="checkout" comment="Alma insurance Data in Quote Item">
         <column xsi:type="text" name="alma_insurance" nullable="true" comment="Alma insurance"/>
@@ -12,31 +16,42 @@
 
     <table name="alma_insurance_subscription" resource="checkout" comment="Alma insurance subscriptions">
         <column xsi:type="int" name="entity_id" identity="true" comment="Auto increment ID"/>
-        <column xsi:type="int" name="order_id" padding="10" nullable="false" unsigned="true" comment="Subscription Order id"/>
-        <column xsi:type="int" name="order_item_id" padding="10" nullable="false" unsigned="true" comment="Order item id"/>
+        <column xsi:type="int" name="order_id" padding="10" nullable="false" unsigned="true"
+                comment="Subscription Order id"/>
+        <column xsi:type="int" name="order_item_id" padding="10" nullable="false" unsigned="true"
+                comment="Order item id"/>
         <column xsi:type="varchar" name="name" nullable="false" length="255" comment="Insurance Name"/>
         <column xsi:type="varchar" name="subscription_id" nullable="false" length="255" comment="Alma subscription ID"/>
         <column xsi:type="varchar" name="subscription_broker_id" length="255" comment="Subscription broker ID"/>
-        <column xsi:type="varchar" name="subscription_broker_reference" length="255" comment="Subscription broker reference"/>
-        <column xsi:type="int" name="subscription_amount" nullable="false" unsigned="true" comment="Alma subscription Price"/>
-        <column xsi:type="varchar" name="contract_id" nullable="false" length="255"  comment="Alma contract ID"/>
+        <column xsi:type="varchar" name="subscription_broker_reference" length="255"
+                comment="Subscription broker reference"/>
+        <column xsi:type="int" name="subscription_amount" nullable="false" unsigned="true"
+                comment="Alma subscription Price"/>
+        <column xsi:type="varchar" name="contract_id" nullable="false" length="255" comment="Alma contract ID"/>
         <column xsi:type="varchar" name="cms_reference" nullable="false" length="255" comment="cms reference - SKU"/>
-        <column xsi:type="varchar" name="linked_product_name" nullable="false" length="255" comment="Name of insured product"/>
+        <column xsi:type="varchar" name="linked_product_name" nullable="false" length="255"
+                comment="Name of insured product"/>
         <column xsi:type="int" name="linked_product_price" nullable="false" comment="Price of insured product"/>
-        <column xsi:type="varchar" name="subscription_state" nullable="false" length="255" comment="Subscription state"/>
+        <column xsi:type="varchar" name="subscription_state" nullable="false" length="255"
+                comment="Subscription state"/>
         <column xsi:type="varchar" name="mode" nullable="false" length="10" comment="Subscription mode live/test"/>
         <column xsi:type="datetime" name="date_of_cancelation" nullable="true" comment="Cancellation date"/>
         <column xsi:type="datetime" name="date_of_cancelation_request" nullable="true" comment="Cancellation date"/>
-        <column xsi:type="varchar" name="reason_of_cancelation" nullable="true" length="255" comment="Cancellation reason"/>
+        <column xsi:type="varchar" name="reason_of_cancelation" nullable="true" length="255"
+                comment="Cancellation reason"/>
         <column xsi:type="boolean" name="is_refunded" default="false" comment="Confirm subscription refund"/>
         <column xsi:type="varchar" name="callback_url" nullable="false" length="255" comment="Callback url for update"/>
         <constraint xsi:type="primary" referenceId="PRIMARY">
             <column name="entity_id"/>
         </constraint>
-        <constraint xsi:type="foreign" referenceId="ALMA_SUBSCRIPTION_ORDER_ID_SALES_ORDER_ENTITY_ID" table="alma_insurance_subscription" column="order_id" referenceTable="sales_order" referenceColumn="entity_id" onDelete="CASCADE"/>
-        <constraint xsi:type="foreign" referenceId="ALMA_SUBSCRIPTION_ORDER_ITEM_ID_SALES_ORDER_ITEM_ID" table="alma_insurance_subscription" column="order_item_id" referenceTable="sales_order_item" referenceColumn="item_id" onDelete="CASCADE"/>
+        <constraint xsi:type="foreign" referenceId="ALMA_SUBSCRIPTION_ORDER_ID_SALES_ORDER_ENTITY_ID"
+                    table="alma_insurance_subscription" column="order_id" referenceTable="sales_order"
+                    referenceColumn="entity_id" onDelete="CASCADE"/>
+        <constraint xsi:type="foreign" referenceId="ALMA_SUBSCRIPTION_ORDER_ITEM_ID_SALES_ORDER_ITEM_ID"
+                    table="alma_insurance_subscription" column="order_item_id" referenceTable="sales_order_item"
+                    referenceColumn="item_id" onDelete="CASCADE"/>
         <index referenceId="SUBSCRIPTION_EXTERNAL_ID" indexType="btree">
-            <column name="subscription_id" />
+            <column name="subscription_id"/>
         </index>
 
     </table>

--- a/etc/events.xml
+++ b/etc/events.xml
@@ -28,21 +28,31 @@
                   instance="Alma\MonthlyPayments\Observer\PaymentDataAssignObserver"/>
     </event>
     <event name="checkout_cart_product_add_after">
-        <observer name="checkout_cart_product_add_after_alma_insurance" instance="Alma\MonthlyPayments\Observer\AddToCartInsuranceObserver" />
+        <observer name="checkout_cart_product_add_after_alma_insurance"
+                  instance="Alma\MonthlyPayments\Observer\AddToCartInsuranceObserver"/>
     </event>
     <event name="sales_quote_remove_item">
-        <observer name="checkout_cart_product_remove_after_alma_insurance" instance="Alma\MonthlyPayments\Observer\RemoveToCartInsuranceObserver" />
+        <observer name="checkout_cart_product_remove_after_alma_insurance"
+                  instance="Alma\MonthlyPayments\Observer\RemoveToCartInsuranceObserver"/>
     </event>
     <event name="checkout_submit_all_after">
-        <observer name="alma_insurance_checkout_submit_all_after" instance="Alma\MonthlyPayments\Observer\CheckoutSubmitAllAfter" />
+        <observer name="alma_insurance_checkout_submit_all_after"
+                  instance="Alma\MonthlyPayments\Observer\CheckoutSubmitAllAfter"/>
     </event>
     <event name="sales_order_invoice_pay">
-        <observer name="alma_insurance_sales_order_invoice_pay" instance="Alma\MonthlyPayments\Observer\SalesOrderInvoicePayObserver" />
+        <observer name="alma_insurance_sales_order_invoice_pay"
+                  instance="Alma\MonthlyPayments\Observer\SalesOrderInvoicePayObserver"/>
     </event>
     <event name="sales_order_save_after">
-        <observer name="sales_order_save_after_order_status" instance="Alma\MonthlyPayments\Observer\OrderStatusObserver" />
+        <observer name="sales_order_save_after_order_status"
+                  instance="Alma\MonthlyPayments\Observer\OrderStatusObserver"/>
     </event>
     <event name="sales_order_shipment_track_save_after">
-        <observer name="sales_order_shipment_track_save_after" instance="Alma\MonthlyPayments\Observer\ShipmentTrackObserver" />
+        <observer name="sales_order_shipment_track_save_after"
+                  instance="Alma\MonthlyPayments\Observer\ShipmentTrackObserver"/>
+    </event>
+    <event name="sales_quote_save_after">
+        <observer name="alma_sales_quote_save_after"
+                  instance="Alma\MonthlyPayments\Observer\SalesQuoteSaveAfterObserver"/>
     </event>
 </config>


### PR DESCRIPTION
### Reason for change

<!-- Describe here the reason for change, and provide a link to the corresponding Linear task or Sentry issue. -->

[Linear task](https://linear.app/almapay/issue/ECOM-2302/adobe-commerce-clean-code-and-deploy)

### Code changes

Create a new service  and send orderConfirmedBusinessEvent to Alma with php  DTO object at payment validation.

### How to test

Not testable for the moment waiting for API release

<!-- Describe here how to test your changes, if applicable. Insert UI screenshots when relevant -->

### Checklist for authors and reviewers

<!-- Move to the next section the non applicable items -->

- [ ] The title of the PR uses business wording, not technical jargon, for the changelog readers to understand it
- [ ] The PR implements the changes asked in the referenced task / issue
- [ ] The automated tests are compliant with the [testing strategy](https://www.notion.so/almapay/Backend-testing-strategy-06c642cec1bf47b9b8feca3a91ea8d4a)
- [ ] The tests are relevant, and cover the corner/error cases, not only the happy path
- [ ] You understand the impact of this PR on existing code/features
- [ ] The changes include adequate logging and Datadog traces
- [ ] Documentation is updated (API, developer documentation, ADR, Notion...)

### Non applicable

<!-- Move here non applicable items of the checklist, if any -->
