### PR TITLE
feat: add CartInitiated notification

### DIFF
--- a/Observer/SalesQuoteSaveAfterObserver.php
+++ b/Observer/SalesQuoteSaveAfterObserver.php
@@ -1,0 +1,51 @@
+<?php
+
+namespace Alma\MonthlyPayments\Observer;
+
+
+use Alma\MonthlyPayments\Helpers\Logger;
+use Alma\MonthlyPayments\Services\MerchantBusinessService;
+use Magento\Framework\Event\Observer;
+use Magento\Framework\Event\ObserverInterface;
+use Magento\Quote\Model\Quote;
+
+
+class SalesQuoteSaveAfterObserver implements ObserverInterface
+{
+    /**
+     * @var Logger
+     */
+    private $logger;
+    /**
+     * @var MerchantBusinessService
+     */
+    private $merchantBusinessService;
+
+    /**
+     * @param Logger $logger
+     * @param MerchantBusinessService $merchantBusinessService
+     */
+    public function __construct(
+        Logger                  $logger,
+        MerchantBusinessService $merchantBusinessService
+    )
+    {
+        $this->logger = $logger;
+        $this->merchantBusinessService = $merchantBusinessService;
+    }
+
+    /**
+     * @param Observer $observer
+     * @return void
+     */
+    public function execute(Observer $observer): void
+    {
+        /** @var Quote $quote */
+        $quote = $observer->getEvent()->getData('quote');
+        if (!$this->merchantBusinessService->isSendCartInitiatedNotification($quote)) {
+            $this->merchantBusinessService->createAndSendCartInitiatedBusinessEvent($quote);
+        }
+    }
+
+
+}

--- a/Test/Unit/Observer/SalesQuoteSaveAfterObserverTest.php
+++ b/Test/Unit/Observer/SalesQuoteSaveAfterObserverTest.php
@@ -1,0 +1,83 @@
+<?php
+
+namespace Alma\MonthlyPayments\Test\Unit\Observer;
+
+use Alma\MonthlyPayments\Helpers\Logger;
+use Alma\MonthlyPayments\Observer\SalesQuoteSaveAfterObserver;
+use Alma\MonthlyPayments\Services\MerchantBusinessService;
+use Magento\Framework\Event;
+use Magento\Framework\Event\Observer;
+use Magento\Quote\Model\Quote;
+use PHPUnit\Framework\TestCase;
+
+class SalesQuoteSaveAfterObserverTest extends TestCase
+{
+
+    /**
+     * @var Logger
+     */
+    private $logger;
+
+    /**
+     * @var MerchantBusinessService
+     */
+    private $merchantBusinessService;
+    /**
+     * @var SalesQuoteSaveAfterObserver
+     */
+    private $salesQuoteSaveAfterObserver;
+
+    public function setUp(): void
+    {
+        $this->logger = $this->createMock(Logger::class);
+        $this->merchantBusinessService = $this->createMock(MerchantBusinessService::class);
+        $this->salesQuoteSaveAfterObserver = new SalesQuoteSaveAfterObserver(
+            $this->logger,
+            $this->merchantBusinessService
+        );
+    }
+
+    public function testExecuteCartInitiatedNotificationNotSend()
+    {
+        $observer = $this->createMock(Observer::class);
+        $quote = $this->createMock(Quote::class);
+        $event = $this->createMock(Event::class);
+        $event->method('getData')->with('quote')->willReturn($quote);
+        $observer->method('getEvent')->willReturn($event);
+        $quote->method('getId')->willReturn(42);
+        $this->merchantBusinessService
+            ->expects($this->once())
+            ->method('isSendCartInitiatedNotification')
+            ->with($quote)
+            ->willReturn(false);
+        $this->merchantBusinessService
+            ->expects($this->once())
+            ->method('createAndSendCartInitiatedBusinessEvent')
+            ->with($quote);
+
+        $this->salesQuoteSaveAfterObserver->execute($observer);
+    }
+
+    public function testExecuteCartInitiatedNotificationAlreadySend()
+    {
+        $observer = $this->createMock(Observer::class);
+        $quote = $this->createMock(Quote::class);
+        $event = $this->createMock(Event::class);
+        $event->method('getData')->with('quote')->willReturn($quote);
+        $observer->method('getEvent')->willReturn($event);
+        $quote->method('getId')->willReturn(42);
+        $this->merchantBusinessService
+            ->expects($this->once())
+            ->method('isSendCartInitiatedNotification')
+            ->with($quote)
+            ->willReturn(true);
+
+        $this->merchantBusinessService
+            ->expects($this->never())
+            ->method('createAndSendCartInitiatedBusinessEvent')
+            ->with($quote);
+
+        $this->salesQuoteSaveAfterObserver->execute($observer);
+    }
+
+}

--- a/etc/db_schema.xml
+++ b/etc/db_schema.xml
@@ -1,7 +1,11 @@
 <?xml version="1.0"?>
-<schema xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:framework:Setup/Declaration/Schema/etc/schema.xsd">
+<schema xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:noNamespaceSchemaLocation="urn:magento:framework:Setup/Declaration/Schema/etc/schema.xsd">
     <table name="quote" resource="checkout" comment="Alma eligibility for quote">
-        <column xsi:type="boolean" name="alma_bnpl_eligibility" nullable="true" comment="Quote is eligible to alma BNPL"/>
+        <column xsi:type="boolean" name="alma_bnpl_eligibility" nullable="true"
+                comment="Quote is eligible to alma BNPL"/>
+        <column xsi:type="boolean" name="alma_cart_initiated_status" nullable="false" default="false"
+                comment="Cart initiated notification status"/>
     </table>
     <table name="quote_item" resource="checkout" comment="Alma insurance Data in Quote Item">
         <column xsi:type="text" name="alma_insurance" nullable="true" comment="Alma insurance"/>
@@ -12,31 +16,42 @@
 
     <table name="alma_insurance_subscription" resource="checkout" comment="Alma insurance subscriptions">
         <column xsi:type="int" name="entity_id" identity="true" comment="Auto increment ID"/>
-        <column xsi:type="int" name="order_id" padding="10" nullable="false" unsigned="true" comment="Subscription Order id"/>
-        <column xsi:type="int" name="order_item_id" padding="10" nullable="false" unsigned="true" comment="Order item id"/>
+        <column xsi:type="int" name="order_id" padding="10" nullable="false" unsigned="true"
+                comment="Subscription Order id"/>
+        <column xsi:type="int" name="order_item_id" padding="10" nullable="false" unsigned="true"
+                comment="Order item id"/>
         <column xsi:type="varchar" name="name" nullable="false" length="255" comment="Insurance Name"/>
         <column xsi:type="varchar" name="subscription_id" nullable="false" length="255" comment="Alma subscription ID"/>
         <column xsi:type="varchar" name="subscription_broker_id" length="255" comment="Subscription broker ID"/>
-        <column xsi:type="varchar" name="subscription_broker_reference" length="255" comment="Subscription broker reference"/>
-        <column xsi:type="int" name="subscription_amount" nullable="false" unsigned="true" comment="Alma subscription Price"/>
-        <column xsi:type="varchar" name="contract_id" nullable="false" length="255"  comment="Alma contract ID"/>
+        <column xsi:type="varchar" name="subscription_broker_reference" length="255"
+                comment="Subscription broker reference"/>
+        <column xsi:type="int" name="subscription_amount" nullable="false" unsigned="true"
+                comment="Alma subscription Price"/>
+        <column xsi:type="varchar" name="contract_id" nullable="false" length="255" comment="Alma contract ID"/>
         <column xsi:type="varchar" name="cms_reference" nullable="false" length="255" comment="cms reference - SKU"/>
-        <column xsi:type="varchar" name="linked_product_name" nullable="false" length="255" comment="Name of insured product"/>
+        <column xsi:type="varchar" name="linked_product_name" nullable="false" length="255"
+                comment="Name of insured product"/>
         <column xsi:type="int" name="linked_product_price" nullable="false" comment="Price of insured product"/>
-        <column xsi:type="varchar" name="subscription_state" nullable="false" length="255" comment="Subscription state"/>
+        <column xsi:type="varchar" name="subscription_state" nullable="false" length="255"
+                comment="Subscription state"/>
         <column xsi:type="varchar" name="mode" nullable="false" length="10" comment="Subscription mode live/test"/>
         <column xsi:type="datetime" name="date_of_cancelation" nullable="true" comment="Cancellation date"/>
         <column xsi:type="datetime" name="date_of_cancelation_request" nullable="true" comment="Cancellation date"/>
-        <column xsi:type="varchar" name="reason_of_cancelation" nullable="true" length="255" comment="Cancellation reason"/>
+        <column xsi:type="varchar" name="reason_of_cancelation" nullable="true" length="255"
+                comment="Cancellation reason"/>
         <column xsi:type="boolean" name="is_refunded" default="false" comment="Confirm subscription refund"/>
         <column xsi:type="varchar" name="callback_url" nullable="false" length="255" comment="Callback url for update"/>
         <constraint xsi:type="primary" referenceId="PRIMARY">
             <column name="entity_id"/>
         </constraint>
-        <constraint xsi:type="foreign" referenceId="ALMA_SUBSCRIPTION_ORDER_ID_SALES_ORDER_ENTITY_ID" table="alma_insurance_subscription" column="order_id" referenceTable="sales_order" referenceColumn="entity_id" onDelete="CASCADE"/>
-        <constraint xsi:type="foreign" referenceId="ALMA_SUBSCRIPTION_ORDER_ITEM_ID_SALES_ORDER_ITEM_ID" table="alma_insurance_subscription" column="order_item_id" referenceTable="sales_order_item" referenceColumn="item_id" onDelete="CASCADE"/>
+        <constraint xsi:type="foreign" referenceId="ALMA_SUBSCRIPTION_ORDER_ID_SALES_ORDER_ENTITY_ID"
+                    table="alma_insurance_subscription" column="order_id" referenceTable="sales_order"
+                    referenceColumn="entity_id" onDelete="CASCADE"/>
+        <constraint xsi:type="foreign" referenceId="ALMA_SUBSCRIPTION_ORDER_ITEM_ID_SALES_ORDER_ITEM_ID"
+                    table="alma_insurance_subscription" column="order_item_id" referenceTable="sales_order_item"
+                    referenceColumn="item_id" onDelete="CASCADE"/>
         <index referenceId="SUBSCRIPTION_EXTERNAL_ID" indexType="btree">
-            <column name="subscription_id" />
+            <column name="subscription_id"/>
         </index>
 
     </table>

--- a/etc/events.xml
+++ b/etc/events.xml
@@ -28,21 +28,31 @@
                   instance="Alma\MonthlyPayments\Observer\PaymentDataAssignObserver"/>
     </event>
     <event name="checkout_cart_product_add_after">
-        <observer name="checkout_cart_product_add_after_alma_insurance" instance="Alma\MonthlyPayments\Observer\AddToCartInsuranceObserver" />
+        <observer name="checkout_cart_product_add_after_alma_insurance"
+                  instance="Alma\MonthlyPayments\Observer\AddToCartInsuranceObserver"/>
     </event>
     <event name="sales_quote_remove_item">
-        <observer name="checkout_cart_product_remove_after_alma_insurance" instance="Alma\MonthlyPayments\Observer\RemoveToCartInsuranceObserver" />
+        <observer name="checkout_cart_product_remove_after_alma_insurance"
+                  instance="Alma\MonthlyPayments\Observer\RemoveToCartInsuranceObserver"/>
     </event>
     <event name="checkout_submit_all_after">
-        <observer name="alma_insurance_checkout_submit_all_after" instance="Alma\MonthlyPayments\Observer\CheckoutSubmitAllAfter" />
+        <observer name="alma_insurance_checkout_submit_all_after"
+                  instance="Alma\MonthlyPayments\Observer\CheckoutSubmitAllAfter"/>
     </event>
     <event name="sales_order_invoice_pay">
-        <observer name="alma_insurance_sales_order_invoice_pay" instance="Alma\MonthlyPayments\Observer\SalesOrderInvoicePayObserver" />
+        <observer name="alma_insurance_sales_order_invoice_pay"
+                  instance="Alma\MonthlyPayments\Observer\SalesOrderInvoicePayObserver"/>
     </event>
     <event name="sales_order_save_after">
-        <observer name="sales_order_save_after_order_status" instance="Alma\MonthlyPayments\Observer\OrderStatusObserver" />
+        <observer name="sales_order_save_after_order_status"
+                  instance="Alma\MonthlyPayments\Observer\OrderStatusObserver"/>
     </event>
     <event name="sales_order_shipment_track_save_after">
-        <observer name="sales_order_shipment_track_save_after" instance="Alma\MonthlyPayments\Observer\ShipmentTrackObserver" />
+        <observer name="sales_order_shipment_track_save_after"
+                  instance="Alma\MonthlyPayments\Observer\ShipmentTrackObserver"/>
+    </event>
+    <event name="sales_quote_save_after">
+        <observer name="alma_sales_quote_save_after"
+                  instance="Alma\MonthlyPayments\Observer\SalesQuoteSaveAfterObserver"/>
     </event>
 </config>


### PR DESCRIPTION
### Reason for change

<!-- Describe here the reason for change, and provide a link to the corresponding Linear task or Sentry issue. -->

Send CartInitiated business event to alma.

[Linear task](https://linear.app/almapay/issue/ECOM-2379/[ac]-merchant-event-cart-initiated)

### Code changes

Add colum to quote table to store alma_cart_initited status.
Observe sales_quote_save_after for sending notification to Alma.

### How to test

_As a reviewer, you are encouraged to test the PR locally._

<!-- Describe here how to test your changes, if applicable. Insert UI screenshots when relevant -->

### Checklist for authors and reviewers

<!-- Move to the next section the non applicable items -->

- [ ] The title of the PR uses business wording, not technical jargon, for the changelog readers to understand it
- [ ] The PR implements the changes asked in the referenced task / issue
- [ ] The automated tests are compliant with the [testing strategy](https://www.notion.so/almapay/Backend-testing-strategy-06c642cec1bf47b9b8feca3a91ea8d4a)
- [ ] The tests are relevant, and cover the corner/error cases, not only the happy path
- [ ] You understand the impact of this PR on existing code/features
- [ ] The changes include adequate logging and Datadog traces
- [ ] Documentation is updated (API, developer documentation, ADR, Notion...)

### Non applicable

<!-- Move here non applicable items of the checklist, if any -->
