### PR TITLE
Use the new endpoint for order status

### DIFF
--- a/Observer/OrderStatusObserver.php
+++ b/Observer/OrderStatusObserver.php
@@ -23,12 +23,15 @@ class OrderStatusObserver implements ObserverInterface
     public function __construct(
         Logger     $logger,
         AlmaClient $almaClient
-    ) {
+    )
+    {
         $this->logger = $logger;
         $this->almaClient = $almaClient;
     }
 
     /**
+     * Execute the observer
+     *
      * @param Observer $observer
      * @return void
      */
@@ -48,24 +51,17 @@ class OrderStatusObserver implements ObserverInterface
         }
 
         $almaPaymentId = $payment->getAdditionalInformation()[Config::ORDER_PAYMENT_ID];
-
         try {
             $almaClient = $this->getAlmaClient();
-            $almaPayment = $this->getAlmaPayment($almaClient, $almaPaymentId);
-            $almaOrder = $this->getAlmaOrder($almaPayment, $order->getIncrementId());
-        } catch (OrderStatusException $e) {
-            $this->logger->error('OrderStatus Exception :', [$e->getMessage()]);
-            return;
-        }
-
-        try {
-            $almaClient->orders->sendStatus($almaOrder->id, ['status' => $order->getStatus() ?? '', 'is_shipped' => $order->hasShipments()]);
-        } catch (AlmaException $e) {
+            $almaClient->payments->addOrderStatusByMerchantOrderReference($almaPaymentId, $order->getIncrementId(), $order->getStatus(), $order->hasShipments());
+        } catch (AlmaException|OrderStatusException $e) {
             $this->logger->error('Impossible to send order Status', [$e->getMessage()]);
         }
     }
 
     /**
+     * Get Alma client and handle exception
+     *
      * @return Client
      * @throws OrderStatusException
      */
@@ -78,39 +74,5 @@ class OrderStatusObserver implements ObserverInterface
         }
     }
 
-    /**
-     * @param Client $almaClient
-     * @param string $almaPaymentId
-     * @return Payment
-     * @throws OrderStatusException
-     */
-    private function getAlmaPayment(Client $almaClient, string $almaPaymentId): Payment
-    {
-        try {
-            return $almaClient->payments->fetch($almaPaymentId);
-        } catch (AlmaException $e) {
-            throw new OrderStatusException('Impossible to fetch Payment', $this->logger, 0, $e);
-        }
-    }
-
-
-    /**
-     * @param Payment $almaPayment
-     * @param string $incrementId
-     * @return AlmaOrder
-     * @throws OrderStatusException
-     */
-    private function getAlmaOrder(Payment $almaPayment, string $incrementId): AlmaOrder
-    {
-        if (empty($almaPayment->orders)) {
-            throw new OrderStatusException(sprintf('No Orders in Alma payment %s', $almaPayment->id), $this->logger);
-        }
-        foreach ($almaPayment->orders as $order) {
-            if ($order->merchant_reference === $incrementId) {
-                return $order;
-            }
-        }
-        throw new OrderStatusException(sprintf('No Order with merchant reference %s in Alma payment %s', $incrementId, $almaPayment->id), $this->logger);
-    }
 
 }

--- a/Test/Unit/Observer/OrderStatusObserverTest.php
+++ b/Test/Unit/Observer/OrderStatusObserverTest.php
@@ -21,17 +21,14 @@ class OrderStatusObserverTest extends TestCase
     private $observer;
 
     private $event;
-    private $ordersEndpoint;
     private $paymentsEndpoint;
     private $almaClient;
 
     protected function setUp(): void
     {
-        $this->ordersEndpoint = $this->createMock(Orders::class);
         $this->paymentsEndpoint = $this->createMock(Payments::class);
 
         $client = $this->createMock(Client::class);
-        $client->orders = $this->ordersEndpoint;
         $client->payments = $this->paymentsEndpoint;
 
         $this->logger = $this->createMock(Logger::class);
@@ -57,7 +54,7 @@ class OrderStatusObserverTest extends TestCase
         $order->method('getState')->willReturn('new');
         $orderStatusObserver = $this->createOrderStatusObserverObject();
         $this->event->method('getData')->willReturn($order);
-        $this->ordersEndpoint->expects($this->never())->method('sendStatus');
+        $this->paymentsEndpoint->expects($this->never())->method('addOrderStatusByMerchantOrderReference');
         $orderStatusObserver->execute($this->observer);
     }
 
@@ -72,11 +69,11 @@ class OrderStatusObserverTest extends TestCase
 
         $orderStatusObserver = $this->createOrderStatusObserverObject();
         $this->event->method('getData')->willReturn($order);
-        $this->ordersEndpoint->expects($this->never())->method('sendStatus');
+        $this->paymentsEndpoint->expects($this->never())->method('addOrderStatusByMerchantOrderReference');
         $orderStatusObserver->execute($this->observer);
     }
 
-    public function testGivenNoAlmaPaymentIdInAdditionalInformationMustReturnWithoutCallAlmaPayment(): void
+    public function testGivenNoAlmaPaymentIdInAdditionalInformationMustReturnWithoutCallAddOrderStatusByMerchantOrderReference(): void
     {
         $payment = $this->createMock(\Magento\Sales\Model\Order\Payment::class);
         $payment->method('getMethod')->willReturn(Config::CODE);
@@ -89,56 +86,11 @@ class OrderStatusObserverTest extends TestCase
 
         $this->event->method('getData')->willReturn($order);
 
-
-        $this->paymentsEndpoint->expects($this->never())->method('fetch');
+        $this->paymentsEndpoint->expects($this->never())->method('addOrderStatusByMerchantOrderReference');
         $this->createOrderStatusObserverObject()->execute($this->observer);
 
     }
 
-    public function testGivenAnAlmaPaymentWithoutOrdersShouldNotCallSendStatus(): void
-    {
-        $payment = $this->createMock(\Magento\Sales\Model\Order\Payment::class);
-        $payment->method('getMethod')->willReturn(Config::CODE);
-        $payment->method('getAdditionalInformation')->willReturn([Config::ORDER_PAYMENT_ID => 'alma_payment_external_id']);
-
-        $order = $this->createMock(\Magento\Sales\Model\Order::class);
-        $order->method('getState')->willReturn('processing');
-        $order->method('getPayment')->willReturn($payment);
-        $order->method('getIncrementId')->willReturn('100000013');
-
-        $this->event->method('getData')->willReturn($order);
-        $almaPayment = $this->createMock(Payment::class);
-        $almaPayment->orders = [];
-
-        $this->paymentsEndpoint->expects($this->once())->method('fetch')->with('alma_payment_external_id')->willReturn($almaPayment);
-        $this->ordersEndpoint->expects($this->never())->method('sendStatus');
-        $this->createOrderStatusObserverObject()->execute($this->observer);
-    }
-
-    public function testGivenAnAlmaPaymentWithOrdersWithBadMerchantReferenceShouldNotCallSendStatus(): void
-    {
-        $payment = $this->createMock(\Magento\Sales\Model\Order\Payment::class);
-        $payment->method('getMethod')->willReturn(Config::CODE);
-        $payment->method('getAdditionalInformation')->willReturn([Config::ORDER_PAYMENT_ID => 'alma_payment_external_id']);
-
-        $order = $this->createMock(\Magento\Sales\Model\Order::class);
-        $order->method('getState')->willReturn('processing');
-        $order->method('getPayment')->willReturn($payment);
-        $order->method('getIncrementId')->willReturn('100000013');
-
-        $this->event->method('getData')->willReturn($order);
-        $almaPayment = $this->createMock(Payment::class);
-
-        $almaOrder = $this->createMock(Order::class);
-        $almaOrder->merchant_reference = '100000012';
-        $almaOrder2 = $this->createMock(Order::class);
-        $almaOrder2->merchant_reference = '100000014';
-        $almaPayment->orders = [$almaOrder, $almaOrder2];
-
-        $this->paymentsEndpoint->expects($this->once())->method('fetch')->with('alma_payment_external_id')->willReturn($almaPayment);
-        $this->ordersEndpoint->expects($this->never())->method('sendStatus');
-        $this->createOrderStatusObserverObject()->execute($this->observer);
-    }
 
     /**
      * @dataProvider orderStatusDataProvider
@@ -158,14 +110,17 @@ class OrderStatusObserverTest extends TestCase
 
         $this->event->method('getData')->willReturn($order);
 
-        $almaOrder = $this->createMock(Order::class);
-        $almaOrder->id = 'alma_order_external_id';
-        $almaOrder->merchant_reference = '100000013';
-        $almaPayment = $this->createMock(Payment::class);
-        $almaPayment->orders = [$almaOrder];
+        $this->paymentsEndpoint->expects($this->never())->method('fetch');
+        $this->paymentsEndpoint
+            ->expects($this->once())
+            ->method('addOrderStatusByMerchantOrderReference')
+            ->with(
+                'alma_payment_external_id',
+                '100000013',
+                $dataProvider['status'],
+                $dataProvider['is_shipped']
 
-        $this->paymentsEndpoint->expects($this->once())->method('fetch')->with('alma_payment_external_id')->willReturn($almaPayment);
-        $this->ordersEndpoint->expects($this->once())->method('sendStatus')->with('alma_order_external_id', ['status' => $dataProvider['status'], 'is_shipped' => $dataProvider['is_shipped']]);
+            );
         $this->createOrderStatusObserverObject()->execute($this->observer);
     }
 


### PR DESCRIPTION
### Reason for change

<!-- Describe here the reason for change, and provide a link to the corresponding Linear task or Sentry issue. -->

[Linear task](https://linear.app/almapay/issue/ECOM-2384/[ac]-use-the-new-endpoint-for-order-status)

### Code changes

Change endpoint to payment and use  addOrderStatusByMerchantOrderReference 
Update test

### How to test

_As a reviewer, you are encouraged to test the PR locally._

<!-- Describe here how to test your changes, if applicable. Insert UI screenshots when relevant -->

### Checklist for authors and reviewers

<!-- Move to the next section the non applicable items -->

- [ ] The title of the PR uses business wording, not technical jargon, for the changelog readers to understand it
- [ ] The PR implements the changes asked in the referenced task / issue
- [ ] The automated tests are compliant with the [testing strategy](https://www.notion.so/almapay/Backend-testing-strategy-06c642cec1bf47b9b8feca3a91ea8d4a)
- [ ] The tests are relevant, and cover the corner/error cases, not only the happy path
- [ ] You understand the impact of this PR on existing code/features
- [ ] The changes include adequate logging and Datadog traces
- [ ] Documentation is updated (API, developer documentation, ADR, Notion...)

### Non applicable

<!-- Move here non applicable items of the checklist, if any -->
