### PR TITLE
Set in page setting to 1 by default

### DIFF
--- a/etc/config.xml
+++ b/etc/config.xml
@@ -49,7 +49,7 @@
                 <can_refund>1</can_refund>
                 <can_use_checkout>1</can_use_checkout>
                 <is_gateway>1</is_gateway>
-                <in_page_enabled>0</in_page_enabled>
+                <in_page_enabled>1</in_page_enabled>
                 <payment_expiration>20</payment_expiration>
                 <excluded_product_types>virtual,downloadable</excluded_product_types>
                 <excluded_products_message>Virtual and downloadable products aren't eligible</excluded_products_message>


### PR DESCRIPTION
### Reason for change

<!-- Describe here the reason for change, and provide a link to the corresponding Linear task or Sentry issue. -->

[Linear task](https://linear.app/almapay/issue/ECOM-2576/[-ac]-set-the-in-page-setting-to-1-by-default)

### Code changes

<!-- Describe here the code changes at a high level. Anything that can help reviewers review your PR. -->
We change the default value for in_page_enabled from 0 to 1
