### PR TITLE
[DEX-1304] Add workflow for Playwright E2E tests

### DIFF
--- a/.github/workflows/e2e-test.yaml
+++ b/.github/workflows/e2e-test.yaml
@@ -13,7 +13,7 @@ jobs:
         version:
         - 2.4.6
     runs-on: ubuntu-24.04
-    #if: github.event.pull_request.draft == false && !contains(github.event.pull_request.labels.*.name, 'hotfix')
+    if: github.event.pull_request.draft == false && !contains(github.event.pull_request.labels.*.name, 'hotfix')
 
     steps:
 

--- a/.github/workflows/e2e-tests-playwright-post-results.yml
+++ b/.github/workflows/e2e-tests-playwright-post-results.yml
@@ -1,4 +1,4 @@
-name: Post E2E results in pull request
+name: Post Playwright E2E results in pull request
 
 on:
   workflow_dispatch:
@@ -31,12 +31,12 @@ jobs:
         uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea # v7.0.1
         with:
             script: |
-              let commentBody = '❌ CodeceptJS E2E tests have failed. \n';
+              let commentBody = '❌ Playwright E2E tests have failed. \n';
               if ('${{ github.event.inputs.e2e-status }}' === 'success') {
-                  commentBody = '✅ CodeceptJS E2E tests have been successfully completed. \n';
+                  commentBody = '✅ Playwright E2E tests have been successfully completed. \n';
               }
               commentBody += '➡️ You can find the results [here](${{ github.event.inputs.e2e-run-url }}).';
-              commentBody += '\n\n<!-- id:e2e-test-run-info -->';
+              commentBody += '\n\n<!-- id:pw-e2e-test-run-info -->';
               github.rest.issues.createComment({
                   issue_number: ${{ github.event.inputs.pr-number }},
                   owner: context.repo.owner,
@@ -47,7 +47,7 @@ jobs:
 
       - name: Generate Github token for PR checks
         id: github-token-checks
-        uses: actions/create-github-app-token@3ff1caaa28b64c9cc276ce0a02e2ff584f3900c5 # v2.0.2
+        uses: actions/create-github-app-token@df432ceedc7162793a195dd1713ff69aefc7379e # v2.0.6
         continue-on-error: true
         with:
           app-id: ${{ secrets.ALMA_UPDATE_CHECKS_APP_ID }}
@@ -62,13 +62,13 @@ jobs:
             let checkStatus = 'completed';
             let checkConclusion = 'success';
             let checkOutput = {
-              title: 'CodeceptJS E2E tests',
-              summary: '✅ CodeceptJS E2E tests have been successfully completed',
+              title: 'Playwright E2E tests',
+              summary: '✅ Playwright E2E tests have been successfully completed',
               text: `➡️ You can find the results [here](${{ github.event.inputs.e2e-run-url }}).`
             };
             if ('${{ github.event.inputs.e2e-status }}' === 'failure') {
               checkConclusion = 'failure';
-              checkOutput.summary = '❌ CodeceptJS E2E tests have failed.';
+              checkOutput.summary = '❌ Playwright E2E tests have failed.';
             }
             github.rest.checks.update({
               owner: context.repo.owner,

--- a/.github/workflows/e2e-tests-playwright.yml
+++ b/.github/workflows/e2e-tests-playwright.yml
@@ -42,21 +42,21 @@ jobs:
               })
               core.setOutput('id', check.data.id)
 
-    - name: Generate a Github token for alma-monthlypayments-magento2-private repo
-      id: github-token-magento2-private
+    - name: Generate a Github token for adobe-commerce-priv repo
+      id: github-token-adobe-commerce-priv
       uses: actions/create-github-app-token@3ff1caaa28b64c9cc276ce0a02e2ff584f3900c5 # v2.0.2
       with:
         app-id: ${{ secrets.ALMA_WF_TRIGGER_APP_ID }}
         private-key: ${{ secrets.ALMA_WF_TRIGGER_APP_PEM }}
-        repositories: alma-monthlypayments-magento2-private
+        repositories: adobe-commerce-priv
 
-    - name: Trigger E2E tests in the alma-monthlypayments-magento2-private repository
+    - name: Trigger E2E tests in the adobe-commerce-priv repository
       uses: codex-/return-dispatch@df6e17379382ea99310623bc5ed1a7dddd6c878f # v2.0.4
       id: e2e-tests-workflow-dispatch
       with:
-          token: ${{ steps.github-token-magento2-private.outputs.token }}
+          token: ${{ steps.github-token-adobe-commerce-priv.outputs.token }}
           ref: main
-          repo: alma-monthlypayments-magento2-private 
+          repo: adobe-commerce-priv
           owner: alma
           workflow: e2e.yml
           workflow_inputs: '{

--- a/.github/workflows/e2e-tests-playwright.yml
+++ b/.github/workflows/e2e-tests-playwright.yml
@@ -1,5 +1,5 @@
 ---
-name: CodeceptJS E2E Tests
+name: Playwright E2E Tests
 on:
   pull_request:
     branches: ["main", "develop"]
@@ -13,11 +13,13 @@ jobs:
         version:
         - 2.4.6
     runs-on: ubuntu-24.04
-    #if: github.event.pull_request.draft == false && !contains(github.event.pull_request.labels.*.name, 'hotfix')
+    # TODO: Uncomment this when the workflow is ready to be used
+    #if: vars.RUN_PLAYWRIGHT_E2E_TESTS == 'true' && github.event.pull_request.draft == false && !contains(github.event.pull_request.labels.*.name, 'hotfix')
+    if: vars.RUN_PLAYWRIGHT_E2E_TESTS == 'true'
 
     steps:
 
-    - name: Generate Github token for PR checks
+    - name: Generate Github token with permissions to create Github checks
       id: github-token-checks
       uses: actions/create-github-app-token@3ff1caaa28b64c9cc276ce0a02e2ff584f3900c5 # v2.0.2
       continue-on-error: true
@@ -26,7 +28,7 @@ jobs:
         private-key: ${{ secrets.ALMA_UPDATE_CHECKS_APP_PEM }}
         repositories: alma-monthlypayments-magento2
 
-    - name: Create a Github check for E2E tests run in the Pull Request
+    - name: Create a Github check for the E2E tests run in the pull request
       if: github.event_name == 'pull_request'
       uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea # v7.0.1
       id: create-github-check
@@ -36,52 +38,47 @@ jobs:
               const check = await github.rest.checks.create({
                   owner: context.repo.owner,
                   repo: context.repo.repo,
-                  name: 'CodeceptJS E2E tests results',
+                  name: 'Playwright E2E tests results',
                   head_sha: '${{ github.event.pull_request.head.sha }}',
                   status: "in_progress",
               })
               core.setOutput('id', check.data.id)
 
-    - name: Generate Github token for integration-infrastructure repo
-      id: github-token-infrastructure
+    - name: Generate a Github token for alma-monthlypayments-magento2-private repo
+      id: github-token-magento2-private
       uses: actions/create-github-app-token@3ff1caaa28b64c9cc276ce0a02e2ff584f3900c5 # v2.0.2
       with:
         app-id: ${{ secrets.ALMA_WF_TRIGGER_APP_ID }}
         private-key: ${{ secrets.ALMA_WF_TRIGGER_APP_PEM }}
-        repositories: integration-infrastructure
+        repositories: alma-monthlypayments-magento2-private
 
-    - name: Trigger E2E tests in the integration-infrastructure repository
+    - name: Trigger E2E tests in the alma-monthlypayments-magento2-private repository
       uses: codex-/return-dispatch@df6e17379382ea99310623bc5ed1a7dddd6c878f # v2.0.4
       id: e2e-tests-workflow-dispatch
       with:
-          token: ${{ steps.github-token-infrastructure.outputs.token }}
-          ref: main
-          repo: integration-infrastructure
+          token: ${{ steps.github-token-magento2-private.outputs.token }}
+          ref: devx/dex-1304-make-e2e-workflow-callable-from-public-repo # TODO: Update this to the main branch
+          repo: alma-monthlypayments-magento2-private 
           owner: alma
-          workflow: deploy-cms.yaml
+          workflow: e2e.yml
           workflow_inputs: '{
-              "name": "e2e-${{ github.run_id }}",
-              "alma_plugin_branch": "${{ github.head_ref || github.ref_name }}",
-              "alma_plugin_test_branch" : "main",
-              "cms":"adobe-commerce-${{ matrix.version }}",
-              "e2e": "true",
-              "e2e_check_info" : "{
-                  \"repository\": \"${{ github.event.repository.name }}\",
+              "adobe_commerce_version":"${{ matrix.version }}",
+              "triggering_github_check_info" : "{
                   \"pr_number\": \"${{ github.event.number }}\",
                   \"check_id\": \"${{ steps.create-github-check.outputs.id  }}\"
                   }"
               }'
-          workflow_timeout_seconds: 120 # Default: 300
+          workflow_timeout_seconds: 300
 
-    - name: Hide deprecated E2E test run info message
-      uses: int128/hide-comment-action@0a9e7919192e41201af6ebd979df163956982d07 # v1.41.0
+    - name: Hide deprecated comment about last E2E tests run
+      uses: int128/hide-comment-action@185e98e4e71b2ee7a4ce37e40c084db335833770 # v1.42.0
       with:
         # This string should be kept in sync with the last words of the comment in :
-        # `Send a comment to the PR informing that the E2E tests are running` step (in this workflow).
-        # `Add a comment with E2E tests results in the Pull Request` step (in e2e-test-post-results workflow)
-        contains: <!-- id:e2e-test-run-info -->
+        # `Add a comment to the PR informing that the E2E tests are running` step (in this workflow).
+        # `Add a comment with E2E tests results in the Pull Request` step (in e2e-tests-playwright-post-results workflow)
+        contains: <!-- id:pw-e2e-test-run-info -->
 
-    - name: Send a comment to the PR informing that the E2E tests are running
+    - name: Add a comment to the PR informing that the E2E tests are running
       if: github.event_name == 'pull_request'
       uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea # v7.0.1
       with:
@@ -90,9 +87,9 @@ jobs:
                   issue_number: context.issue.number,
                   owner: context.repo.owner,
                   repo: context.repo.repo,
-                  body: '⏳CodeceptJS E2E tests are currently running. \n' +
+                  body: '⏳Playwright E2E tests are currently running. \n' +
                       '➡️ You can follow their progression [here](${{steps.e2e-tests-workflow-dispatch.outputs.run_url}}).' +
-                      '\n\n<!-- id:e2e-test-run-info -->'
+                      '\n\n<!-- id:pw-e2e-test-run-info -->'
               })
 
     - name: Update Github check with the E2E tests run URL
@@ -102,8 +99,8 @@ jobs:
           github-token: ${{ steps.github-token-checks.outputs.token }}
           script: |
               const checkOutput = {
-                  title: 'CodeceptJS E2E tests results',
-                  summary: '⏳CodeceptJS E2E tests are currently running.',
+                  title: 'Playwright E2E tests results',
+                  summary: '⏳Playwright E2E tests are currently running.',
                   text: '➡️ You can follow their progression [here](${{steps.e2e-tests-workflow-dispatch.outputs.run_url}}).'
               };
               github.rest.checks.update({

--- a/.github/workflows/e2e-tests-playwright.yml
+++ b/.github/workflows/e2e-tests-playwright.yml
@@ -13,9 +13,7 @@ jobs:
         version:
         - 2.4.6
     runs-on: ubuntu-24.04
-    # TODO: Uncomment this when the workflow is ready to be used
-    #if: vars.RUN_PLAYWRIGHT_E2E_TESTS == 'true' && github.event.pull_request.draft == false && !contains(github.event.pull_request.labels.*.name, 'hotfix')
-    if: vars.RUN_PLAYWRIGHT_E2E_TESTS == 'true'
+    if: vars.RUN_PLAYWRIGHT_E2E_TESTS == 'true' && github.event.pull_request.draft == false && !contains(github.event.pull_request.labels.*.name, 'hotfix')
 
     steps:
 
@@ -57,7 +55,7 @@ jobs:
       id: e2e-tests-workflow-dispatch
       with:
           token: ${{ steps.github-token-magento2-private.outputs.token }}
-          ref: devx/dex-1304-make-e2e-workflow-callable-from-public-repo # TODO: Update this to the main branch
+          ref: main
           repo: alma-monthlypayments-magento2-private 
           owner: alma
           workflow: e2e.yml

--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,6 @@ auth.json
 .idea
 /Test/.phpunit.result.cache
 .phpunit.result.cache
+
+# Taskfile
+.task


### PR DESCRIPTION
### Reason for change

<!-- Describe here the reason for change, and provide a link to the corresponding Linear task or Sentry issue. -->

CodeceptJS E2E tests will be migrated to Playwright, on the new repository `alma-monthlypayments-magento2-private`.
We want `alma-monthlypayments-magento2` PRs to trigger these new Playwright E2E tests in addition of the legacy CodeceptJS E2E tests, throughout the entire migration.

### Code changes

<!-- Describe here the code changes at a high level. Anything that can help reviewers review your PR. -->
This PR adds 2 new workflows, that are based on the existing workflows for CodeceptJS.
* `e2e-tests-playwright.yml` which triggers the `e2e.yml` workflow of `alma-monthlypayments-magento2-private`.
* `e2e-tests-playwright-post-results.yml` which is called by the `e2e.yml` workflow when tests are finished, to post the results on the pull requests

> [!IMPORTANT]  
> Playwright E2E tests will be triggered only if the Github var `RUN_PLAYWRIGHT_E2E_TESTS `is set to "true". It is currently set to "false" as the migration has not started yet.

> [!NOTE]  
> This PR is based on the main branch purposely, because the new `e2e-tests-playwright-post-results.yml` workflow will be called on the default branch (main) by the `e2e.yml` workflow

> [!NOTE]  
> There will be 2 Github checks for the E2E tests: 1 for the CodeceptJS E2E tests, and 1 for the Playwright E2E tests. Also, separate comments will be posted in the PR to inform about the E2E tests runs start and results.

