### PR TITLE
fix: Error previous order without shipping method

### DIFF
--- a/Helpers/OrderHelper.php
+++ b/Helpers/OrderHelper.php
@@ -162,7 +162,7 @@ class OrderHelper extends AbstractHelper
      */
     public function getOrderShippingMethodName(Order $order): string
     {
-        return $order->getShippingMethod();
+        return $order->getShippingMethod() ?? '';
     }
 
     /**


### PR DESCRIPTION
### Reason for change

<!-- Describe here the reason for change, and provide a link to the corresponding Linear task or Sentry issue. -->

[Linear task](https://linear.app/almapay/issue/ECOM-2858/airsoft-entrepot)

### Code changes

<!-- Describe here the code changes at a high level. Anything that can help reviewers review your PR. -->
In the function `getOrderShippingMethodName` to keep the string type, we return empty string is the value is null

### How to test

_As a reviewer, you are encouraged to test the PR locally._

<!-- Describe here how to test your changes, if applicable. Insert UI screenshots when relevant -->
Make an order without shipping method (virtual product) and make an other order with and check the value of "shipping_method" in previous order, null must be ""

### Checklist for authors and reviewers

<!-- Move to the next section the non applicable items -->

- [ ] The title of the PR uses business wording, not technical jargon, for the changelog readers to understand it
- [ ] The PR implements the changes asked in the referenced task / issue
- [ ] The automated tests are compliant with the [testing strategy](https://www.notion.so/almapay/Backend-testing-strategy-06c642cec1bf47b9b8feca3a91ea8d4a)
- [ ] The tests are relevant, and cover the corner/error cases, not only the happy path
- [ ] You understand the impact of this PR on existing code/features
- [ ] The changes include adequate logging and Datadog traces
- [ ] Documentation is updated (API, developer documentation, ADR, Notion...)

### Non applicable

<!-- Move here non applicable items of the checklist, if any -->
