### PR TITLE
fix  PHP 8.4 Implicitly marking parameter as nullable is deprecated

### DIFF
--- a/Gateway/Config/Config.php
+++ b/Gateway/Config/Config.php
@@ -92,7 +92,7 @@ class Config extends \Magento\Payment\Gateway\Config\Config
         PaymentPlansConfigInterfaceFactory $plansConfigFactory,
         ApiConfigHelper                    $apiConfigHelper,
         RequestInterface                   $request,
-        string                             $methodCode = null,
+        ?string                            $methodCode = null,
         string                             $pathPattern = self::DEFAULT_PATH_PATTERN
     ) {
         parent::__construct($scopeConfig, $methodCode, $pathPattern);

--- a/Helpers/PaymentPlansHelper.php
+++ b/Helpers/PaymentPlansHelper.php
@@ -63,10 +63,10 @@ class PaymentPlansHelper
      * @param ConfigHelper $configHelper
      */
     public function __construct(
-        Logger $logger,
+        Logger                      $logger,
         PaymentPlansConfigInterface $paymentPlansConfig,
-        MessageManager $messageManager,
-        ConfigHelper $configHelper
+        MessageManager              $messageManager,
+        ConfigHelper                $configHelper
     ) {
         $this->logger = $logger;
         $this->configHelper = $configHelper;
@@ -84,7 +84,7 @@ class PaymentPlansHelper
         $feePlans = $this->configHelper->getBaseApiPlansConfig();
 
         foreach ($feePlans as $plan) {
-            $deferredLimitDays  = $plan->getDeferredTriggerLimitDays();
+            $deferredLimitDays = $plan->getDeferredTriggerLimitDays();
             if (isset($deferredLimitDays)) {
                 $triggerIsAllowed = true;
                 break;
@@ -165,7 +165,7 @@ class PaymentPlansHelper
         $label = $key;
 
         if (isset($matches[1])) {
-            $label =  __('Pay in %1 installments', $matches[1]);
+            $label = __('Pay in %1 installments', $matches[1]);
         }
 
         if (isset($matches[1])
@@ -173,19 +173,19 @@ class PaymentPlansHelper
             && $matches[2] === '0'
             && $matches[3] === '0'
         ) {
-            $label =  __('Pay now');
+            $label = __('Pay now');
         }
 
         if (isset($matches[2])
             && $matches[2] !== '0'
         ) {
-            $label =  __('Pay later - D+%1', $matches[2]);
+            $label = __('Pay later - D+%1', $matches[2]);
         }
 
         if (isset($matches[3])
             && $matches[3] !== '0'
         ) {
-            $label =  __('Pay later - %1 month', $matches[3]);
+            $label = __('Pay later - %1 month', $matches[3]);
         }
 
         return $label;
@@ -218,7 +218,7 @@ class PaymentPlansHelper
      *
      * @return int
      */
-    private function getEnabledDefaultValue(FeePlan $feePlan, array $feePlanConfig = null) : int
+    private function getEnabledDefaultValue(FeePlan $feePlan, ?array $feePlanConfig = null): int
     {
         $key = PaymentPlanConfig::keyForFeePlan($feePlan);
         $defaultEnabled = 0;
@@ -236,8 +236,8 @@ class PaymentPlansHelper
     private function getFee(FeePlan $feePlan): array
     {
         $fee = [];
-        $fee['merchant'] = ['merchant_fee_fixed' => $feePlan->merchant_fee_fixed, 'merchant_fee_variable' => $feePlan->merchant_fee_variable ];
-        $fee['customer'] = ['customer_fee_fixed' => $feePlan->customer_fee_fixed, 'customer_fee_variable' => $feePlan->customer_fee_variable ];
+        $fee['merchant'] = ['merchant_fee_fixed' => $feePlan->merchant_fee_fixed, 'merchant_fee_variable' => $feePlan->merchant_fee_variable];
+        $fee['customer'] = ['customer_fee_fixed' => $feePlan->customer_fee_fixed, 'customer_fee_variable' => $feePlan->customer_fee_variable];
         return $fee;
     }
 

--- a/Model/Adminhtml/Config/ApiKey/APIKeyValue.php
+++ b/Model/Adminhtml/Config/ApiKey/APIKeyValue.php
@@ -93,8 +93,8 @@ class APIKeyValue extends Encrypted
         MessageManager       $messageManager,
         ConfigHelper         $configHelper,
         ApiConfigHelper      $apiConfigHelper,
-        AbstractResource     $resource = null,
-        AbstractDb           $resourceCollection = null,
+        ?AbstractResource    $resource = null,
+        ?AbstractDb          $resourceCollection = null,
         array                $data = []
     ) {
         parent::__construct(

--- a/Model/Adminhtml/Config/ApiUrl/ApiUrlValue.php
+++ b/Model/Adminhtml/Config/ApiUrl/ApiUrlValue.php
@@ -62,8 +62,8 @@ class ApiUrlValue extends Value implements ProcessorInterface
         Registry             $registry,
         ScopeConfigInterface $config,
         TypeListInterface    $cacheTypeList,
-        AbstractResource     $resource = null,
-        AbstractDb           $resourceCollection = null,
+        ?AbstractResource    $resource = null,
+        ?AbstractDb          $resourceCollection = null,
         array                $data = []
     ) {
         parent::__construct($context, $registry, $config, $cacheTypeList, $resource, $resourceCollection, $data);

--- a/Model/Adminhtml/Config/FeePlansConfigBackendModel.php
+++ b/Model/Adminhtml/Config/FeePlansConfigBackendModel.php
@@ -37,8 +37,8 @@ class FeePlansConfigBackendModel extends Value
         SerializerInterface $serialize,
         PaymentPlansHelper $paymentPlansHelper,
         ConfigHelper $configHelper,
-        AbstractResource $resource = null,
-        AbstractDb $resourceCollection = null,
+        ?AbstractResource $resource = null,
+        ?AbstractDb $resourceCollection = null,
         array $data = []
     ) {
         parent::__construct(

--- a/Model/Adminhtml/Config/SOCConsentField.php
+++ b/Model/Adminhtml/Config/SOCConsentField.php
@@ -62,8 +62,8 @@ class SOCConsentField extends Value
         AlmaClient           $almaClient,
         Logger               $logger,
         ManagerInterface     $messageManager,
-        AbstractResource     $resource = null,
-        AbstractDb           $resourceCollection = null
+        ?AbstractResource     $resource = null,
+        ?AbstractDb           $resourceCollection = null
     ) {
         parent::__construct($context, $registry, $config, $cacheTypeList, $resource, $resourceCollection, []);
         $this->socHelper = $socHelper;

--- a/Model/Exceptions/AlmaPaymentValidationException.php
+++ b/Model/Exceptions/AlmaPaymentValidationException.php
@@ -16,7 +16,7 @@ class AlmaPaymentValidationException extends Exception
      * @param int $code
      * @param \Throwable|null $previous
      */
-    public function __construct($message = "", $returnPath = self::RETURN_PATH, $code = 0, \Throwable $previous = null)
+    public function __construct($message = "", $returnPath = self::RETURN_PATH, $code = 0, ?\Throwable $previous = null)
     {
         parent::__construct($message, $code, $previous);
         $this->returnPath = $returnPath;

--- a/Model/Exceptions/InPagePayException.php
+++ b/Model/Exceptions/InPagePayException.php
@@ -6,7 +6,7 @@ use Exception;
 
 class InPagePayException extends Exception
 {
-    public function __construct($message, $logger, $code = 0, \Throwable $previous = null)
+    public function __construct($message, $logger, $code = 0, ?\Throwable $previous = null)
     {
         parent::__construct($message, $code, $previous);
         $logger->warning($message);

--- a/Model/Exceptions/OrderStatusException.php
+++ b/Model/Exceptions/OrderStatusException.php
@@ -6,7 +6,7 @@ use Exception;
 
 class OrderStatusException extends Exception
 {
-    public function __construct($message, $logger, $code = 0, \Throwable $previous = null)
+    public function __construct($message, $logger, $code = 0, ?\Throwable $previous = null)
     {
         parent::__construct($message, $code, $previous);
         $logger->warning($message);

--- a/Test/Unit/Helpers/PaymentValidationTest.php
+++ b/Test/Unit/Helpers/PaymentValidationTest.php
@@ -290,22 +290,22 @@ class PaymentValidationTest extends TestCase
     {
         return [
             'Check with deferred Trigger True' => [
-                    [
-                        'created' => self::FIXED_TIMESTAMP,
-                        'deferred_days' => self::DEFFERED_DAYS_30,
-                        'deferred_trigger' => true,
-                        'deferred_trigger_description' => 'At shipping'
-                    ],
-                    [
-                        'total' => self::TXT_PRICE,
-                        'created' => self::FIXED_TIMESTAMP,
-                        'deferred_days' => self::DEFFERED_DAYS_30,
-                        'installments_count' => '0',
-                        'deferred_months' => '0',
-                        'deferred_trigger' => 'yes',
-                        'deferred_trigger_description' => 'At shipping'
-                    ]
+                [
+                    'created' => self::FIXED_TIMESTAMP,
+                    'deferred_days' => self::DEFFERED_DAYS_30,
+                    'deferred_trigger' => true,
+                    'deferred_trigger_description' => 'At shipping'
                 ],
+                [
+                    'total' => self::TXT_PRICE,
+                    'created' => self::FIXED_TIMESTAMP,
+                    'deferred_days' => self::DEFFERED_DAYS_30,
+                    'installments_count' => '0',
+                    'deferred_months' => '0',
+                    'deferred_trigger' => 'yes',
+                    'deferred_trigger_description' => 'At shipping'
+                ]
+            ],
             'Check with deferred Trigger False' => [
                 [
                     'created' => self::FIXED_TIMESTAMP,

--- a/Test/Unit/Mocks/FeePlanFactoryMock.php
+++ b/Test/Unit/Mocks/FeePlanFactoryMock.php
@@ -14,7 +14,7 @@ class FeePlanFactoryMock
     public static function feePlanFactory(
         string $key,
         bool $allowed = true,
-        string $triggerDays = null,
+        ?string $triggerDays = null,
         int $minAmount = 5000,
         int $maxAmount = 200000
     ): FeePlan {
@@ -32,7 +32,7 @@ class FeePlanFactoryMock
     public static function dataFeePlanFactory(
         string $key,
         bool $allowed = true,
-        string $triggerDays = null,
+        ?string $triggerDays = null,
         int $minAmount = 5000,
         int $maxAmount = 200000
     ): array {


### PR DESCRIPTION
### Reason for change

<!-- Describe here the reason for change, and provide a link to the corresponding Linear task or Sentry issue. -->

https://linear.app/almapay/issue/ECOM-2962/upgrade-our-plugin-to-magento-248-avec-php-84

### Code changes

Add ? for nullable variable

<!-- Describe here the code changes at a high level. Anything that can help reviewers review your PR. -->

### How to test

_As a reviewer, you are encouraged to test the PR locally._

<!-- Describe here how to test your changes, if applicable. Insert UI screenshots when relevant -->

### Checklist for authors and reviewers

<!-- Move to the next section the non applicable items -->

- [ ] The title of the PR uses business wording, not technical jargon, for the changelog readers to understand it
- [ ] The PR implements the changes asked in the referenced task / issue
- [ ] The automated tests are compliant with the [testing strategy](https://www.notion.so/almapay/Backend-testing-strategy-06c642cec1bf47b9b8feca3a91ea8d4a)
- [ ] The tests are relevant, and cover the corner/error cases, not only the happy path
- [ ] You understand the impact of this PR on existing code/features
- [ ] The changes include adequate logging and Datadog traces
- [ ] Documentation is updated (API, developer documentation, ADR, Notion...)

### Non applicable

<!-- Move here non applicable items of the checklist, if any -->
