### PR TITLE
fix(webapi): Swagger schema generation for collect endpoint

### DIFF
--- a/Api/Data/CollectDataInterface.php
+++ b/Api/Data/CollectDataInterface.php
@@ -2,13 +2,11 @@
 
 namespace Alma\MonthlyPayments\Api\Data;
 
-use Magento\Framework\App\ResponseInterface;
-
 interface CollectDataInterface
 {
     /**
      * Collect configuration data Api return void value but an HTTP response is sent to the client
-     * @return ResponseInterface
+     * @return void
      */
     public function collect();
 }


### PR DESCRIPTION
### Reason for change

Swagger schema generation was failing because the API contract declared a ResponseInterface return type in the PHPDoc. Magento WebAPI expects API methods to return supported data types and could not resolve this type while building the schema.

[Linear task](https://linear.app/almapay/issue/ECOM-4262/module-break-magento-api-reflection)

### Code changes

- Updated the PHPDoc return type of the collect() API method from ResponseInterface to void.
- This aligns the API contract with the actual behavior of the endpoint and restores Swagger schema generation.

### How to test

1. Deploy the module locally.
2. Open the Swagger documentation endpoint.
3. Verify that the schema is generated successfully and no longer throws:
   - The "ResponseInterface" class doesn't exist and the namespace must be specified.
4. Verify that the collect endpoint remains accessible and behaves as before.