### PR TITLE
fix: Fix getUrl() on Magento Fresh install

### DIFF
--- a/Model/Adminhtml/Config/ApiUrl/ApiUrlValue.php
+++ b/Model/Adminhtml/Config/ApiUrl/ApiUrlValue.php
@@ -27,6 +27,7 @@ namespace Alma\MonthlyPayments\Model\Adminhtml\Config\ApiUrl;
 use Magento\Framework\App\Cache\TypeListInterface;
 use Magento\Framework\App\Config\Data\ProcessorInterface;
 use Magento\Framework\App\Config\ScopeConfigInterface;
+use Magento\Framework\App\DeploymentConfig;
 use Magento\Framework\App\Config\Value;
 use Magento\Framework\Data\Collection\AbstractDb;
 use Magento\Framework\Model\Context;
@@ -46,14 +47,20 @@ class ApiUrlValue extends Value implements ProcessorInterface
     private $url;
 
     /**
+     * @var DeploymentConfig
+     */
+    private $deploymentConfig;
+
+    /**
      * ApiUrlValue constructor.
+     * @param Url $url
      * @param Context $context
      * @param Registry $registry
      * @param ScopeConfigInterface $config
      * @param TypeListInterface $cacheTypeList
+     * @param DeploymentConfig $deploymentConfig
      * @param AbstractResource|null $resource
      * @param AbstractDb|null $resourceCollection
-     * @param Url $url
      * @param array $data
      */
     public function __construct(
@@ -62,12 +69,24 @@ class ApiUrlValue extends Value implements ProcessorInterface
         Registry             $registry,
         ScopeConfigInterface $config,
         TypeListInterface    $cacheTypeList,
+        DeploymentConfig     $deploymentConfig,
         ?AbstractResource    $resource = null,
         ?AbstractDb          $resourceCollection = null,
         array                $data = []
     ) {
         parent::__construct($context, $registry, $config, $cacheTypeList, $resource, $resourceCollection, $data);
         $this->url = $url;
+        $this->deploymentConfig = $deploymentConfig;
+    }
+
+    /**
+     * @return bool
+     * @throws \Magento\Framework\Exception\FileSystemException
+     * @throws \Magento\Framework\Exception\RuntimeException
+     */
+    private function isMagentoInstalled(): bool
+    {
+        return $this->deploymentConfig->isAvailable();
     }
 
     /**
@@ -75,6 +94,10 @@ class ApiUrlValue extends Value implements ProcessorInterface
      */
     public function processValue($value): string
     {
+        if (!$this->isMagentoInstalled()) {
+            return (string) $value;
+        }
+
         if (empty($value)) {
             $value = $this->url->getUrl(
                 $this->urlPath,
@@ -89,6 +112,10 @@ class ApiUrlValue extends Value implements ProcessorInterface
      */
     public function getOldDefaultUrl(): string
     {
+        if (!$this->isMagentoInstalled()) {
+            return '';
+        }
+
         return $this->url->getUrl(
             $this->oldUrlPath,
             ['_nosid' => true, '_type' => UrlInterface::URL_TYPE_WEB]


### PR DESCRIPTION
### Reason for change

Installing Magento with the Alma module already present aborts during `bin/magento setup:install`:

[Linear task](https://linear.app/almapay/issue/ECOM-4508/fix-release-plugin-582-on-magento-2)

### How to test

On a **fresh** Magento (no `app/etc/env.php`), with the module present

Expected: the install completes. Before the fix it stops on "The default website isn't defined. Set the website and try again."

### Checklist for authors and reviewers

<!-- Move to the next section the non applicable items -->

- [X] The title of the PR uses business wording, not technical jargon, for the changelog readers to understand it
- [X] The PR implements the changes asked in the referenced task / issue
- [X] The automated tests are compliant with the [testing strategy](https://www.notion.so/almapay/Backend-testing-strategy-06c642cec1bf47b9b8feca3a91ea8d4a)
- [X] The tests are relevant, and cover the corner/error cases, not only the happy path
- [X] You understand the impact of this PR on existing code/features
