### PR TITLE
ci(permissions): use shared alma-automations github app for all CI operations

### DIFF
--- a/.github/workflows/e2e-test-post-results.yml
+++ b/.github/workflows/e2e-test-post-results.yml
@@ -50,9 +50,10 @@ jobs:
         uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
         continue-on-error: true
         with:
-          app-id: ${{ secrets.ALMA_UPDATE_CHECKS_APP_ID }}
-          private-key: ${{ secrets.ALMA_UPDATE_CHECKS_APP_PEM }}
+          client-id: ${{ vars.ALMA_AUTOMATIONS_CLIENT_ID }}
+          private-key: ${{ secrets.ALMA_AUTOMATIONS_PRIVATE_KEY }}
           repositories: alma-monthlypayments-magento2
+          permission-checks: write  # update checks
 
       - name: Update check in PR with E2E tests results
         uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0

--- a/.github/workflows/e2e-test.yaml
+++ b/.github/workflows/e2e-test.yaml
@@ -22,9 +22,10 @@ jobs:
       uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
       continue-on-error: true
       with:
-        app-id: ${{ secrets.ALMA_UPDATE_CHECKS_APP_ID }}
-        private-key: ${{ secrets.ALMA_UPDATE_CHECKS_APP_PEM }}
+        client-id: ${{ vars.ALMA_AUTOMATIONS_CLIENT_ID }}
+        private-key: ${{ secrets.ALMA_AUTOMATIONS_PRIVATE_KEY }}
         repositories: alma-monthlypayments-magento2
+        permission-checks: write  # update checks
 
     - name: Create a Github check for E2E tests run in the Pull Request
       if: github.event_name == 'pull_request'
@@ -46,9 +47,10 @@ jobs:
       id: github-token-infrastructure
       uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
       with:
-        app-id: ${{ secrets.ALMA_WF_TRIGGER_APP_ID }}
-        private-key: ${{ secrets.ALMA_WF_TRIGGER_APP_PEM }}
+        client-id: ${{ vars.ALMA_AUTOMATIONS_CROSS_REPO_CLIENT_ID }}
+        private-key: ${{ secrets.ALMA_AUTOMATIONS_CROSS_REPO_PRIVATE_KEY }}
         repositories: integration-infrastructure
+        permission-actions: write  # trigger workflow
 
     - name: Trigger E2E tests in the integration-infrastructure repository
       uses: codex-/return-dispatch@2e404d40b641ba1deb44be941660bb34828e4f6d # v4.0.0

--- a/.github/workflows/e2e-tests-playwright-post-results.yml
+++ b/.github/workflows/e2e-tests-playwright-post-results.yml
@@ -50,9 +50,10 @@ jobs:
         uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
         continue-on-error: true
         with:
-          app-id: ${{ secrets.ALMA_UPDATE_CHECKS_APP_ID }}
-          private-key: ${{ secrets.ALMA_UPDATE_CHECKS_APP_PEM }}
+          client-id: ${{ vars.ALMA_AUTOMATIONS_CLIENT_ID }}
+          private-key: ${{ secrets.ALMA_AUTOMATIONS_PRIVATE_KEY }}
           repositories: alma-monthlypayments-magento2
+          permission-checks: write  # update checks
 
       - name: Update check in PR with E2E tests results
         uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0

--- a/.github/workflows/e2e-tests-playwright.yml
+++ b/.github/workflows/e2e-tests-playwright.yml
@@ -22,9 +22,10 @@ jobs:
       uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
       continue-on-error: true
       with:
-        app-id: ${{ secrets.ALMA_UPDATE_CHECKS_APP_ID }}
-        private-key: ${{ secrets.ALMA_UPDATE_CHECKS_APP_PEM }}
+        client-id: ${{ vars.ALMA_AUTOMATIONS_CLIENT_ID }}
+        private-key: ${{ secrets.ALMA_AUTOMATIONS_PRIVATE_KEY }}
         repositories: alma-monthlypayments-magento2
+        permission-checks: write  # update checks
 
     - name: Create a Github check for the E2E tests run in the pull request
       if: github.event_name == 'pull_request'
@@ -46,9 +47,10 @@ jobs:
       id: github-token-adobe-commerce-priv
       uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
       with:
-        app-id: ${{ secrets.ALMA_WF_TRIGGER_APP_ID }}
-        private-key: ${{ secrets.ALMA_WF_TRIGGER_APP_PEM }}
+        client-id: ${{ vars.ALMA_AUTOMATIONS_CROSS_REPO_CLIENT_ID }}
+        private-key: ${{ secrets.ALMA_AUTOMATIONS_CROSS_REPO_PRIVATE_KEY }}
         repositories: adobe-commerce-priv
+        permission-actions: write  # trigger workflow
 
     - name: Trigger E2E tests in the adobe-commerce-priv repository
       uses: codex-/return-dispatch@2e404d40b641ba1deb44be941660bb34828e4f6d # v4.0.0

--- a/.github/workflows/release-pull-request.yml
+++ b/.github/workflows/release-pull-request.yml
@@ -50,9 +50,11 @@ jobs:
         uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
         id: github-token
         with:
-          app-id: ${{ secrets.ALMA_CREATE_TEAM_PRS_APP_ID }}
-          private-key: ${{ secrets.ALMA_CREATE_TEAM_PRS_APP_PEM }}
+          client-id: ${{ vars.ALMA_AUTOMATIONS_CROSS_REPO_CLIENT_ID }}
+          private-key: ${{ secrets.ALMA_AUTOMATIONS_CROSS_REPO_PRIVATE_KEY }}
           repositories: alma-monthlypayments-magento2
+          permission-contents: write  # push branch
+          permission-pull-requests: write  # create pull-request
 
       - name: Create Pull Request
         uses: peter-evans/create-pull-request@5f6978faf089d4d20b00c7766989d076bb2fc7f1 # v8.1.1


### PR DESCRIPTION
We're moving to reduce the amount of similar Github apps used throughout our CI, as well as asking for **explicit permissions** for all Github token generations.

For this repository, we have `Alma - Automations` for operations on the same repository, and `Alma - Automations (cross-repo)` for operations that needs to reach other repositories.

---

closes [DEX-2363](https://linear.app/almapay/issue/DEX-2363/use-the-alma-automations-app-in-almaalma-monthlypayments-magento2)